### PR TITLE
"Lock user changed attributes" REST call generates RFCs 

### DIFF
--- a/transistor/src/main/java/com/oneops/transistor/service/DesignManager.java
+++ b/transistor/src/main/java/com/oneops/transistor/service/DesignManager.java
@@ -52,6 +52,6 @@ public interface DesignManager {
 	EnvironmentExportSimple exportEnvironment(long envId, Long[] platformIds, String scope);
 	long importEnvironment(long assemblyId, String userId, String scope, EnvironmentExportSimple ees);
 
-    long lockUserChangedAttributes(long assemblyId, String scope);
+    long lockUserChangedAttributes(long assemblyId, String scope, String userId, boolean dryRun);
 }
 

--- a/transistor/src/main/java/com/oneops/transistor/service/DesignManagerImpl.java
+++ b/transistor/src/main/java/com/oneops/transistor/service/DesignManagerImpl.java
@@ -107,8 +107,8 @@ public class DesignManagerImpl implements DesignManager {
 	}
 
 	@Override
-	public long lockUserChangedAttributes(long assemblyId, String scope) {
-		return designExpProcessor.lockUserChangedAttributes(assemblyId, scope);
+	public long lockUserChangedAttributes(long assemblyId, String scope, String userId, boolean dryRun) {
+		return designExpProcessor.lockUserChangedAttributes(assemblyId, scope, userId, dryRun);
 	}
 
 	@Override

--- a/transistor/src/main/java/com/oneops/transistor/ws/rest/TransistorRestController.java
+++ b/transistor/src/main/java/com/oneops/transistor/ws/rest/TransistorRestController.java
@@ -273,17 +273,18 @@ public class TransistorRestController extends AbstractRestController {
 	}
 
 
-	@RequestMapping(value="/assemblies/{assemblyId}/lockUserChangedAttributes", method = RequestMethod.GET)
+	@RequestMapping(value="/assemblies/{assemblyId}/lockUserChangedAttributes", method = RequestMethod.PUT)
 	@ResponseBody
 	public Long lockUserChangedAttributes(
 			@PathVariable long assemblyId,
+			@RequestParam(value="dryRun", required= false) boolean dryRun, 
 			@RequestHeader(value="X-Cms-User", required = false)  String userId,
 			@RequestHeader(value="X-Cms-Scope", required = false)  String scope){
 
 		if (userId == null) userId = "oneops-system";
 		try {
 			long startTime = System.currentTimeMillis();
-			long updateCount = dManager.lockUserChangedAttributes(assemblyId, scope);
+			long updateCount = dManager.lockUserChangedAttributes(assemblyId, scope, userId, dryRun);
 			logger.info("Assembly "+assemblyId+" user modified attribute locking time - "+ (System.currentTimeMillis()-startTime)+" ms");
 			return updateCount;
 		}  catch (Exception te) {


### PR DESCRIPTION
instead of modifying CI object directly, to be consistent with the rest of the API