### PR TITLE
Fixed several issues with the current packer setup.

### DIFF
--- a/oneops-packer/centos.json
+++ b/oneops-packer/centos.json
@@ -71,6 +71,11 @@
       "destination": "/tmp/init-d-display"
     },
     {
+      "type": "file",
+      "source": "files/ruby/binaries/centos/7/x86_64/ruby-2.3.3.tar.bz2",
+      "destination": "/tmp/ruby-2.3.3.tar.bz2"
+    },
+    {
       "environment_vars": [
         "CM={{user `cm`}}",
         "CM_VERSION={{user `cm_version`}}",

--- a/oneops-packer/files/display/display
+++ b/oneops-packer/files/display/display
@@ -9,6 +9,9 @@
 # Source networking configuration.
 . /etc/sysconfig/network
 
+# source rvm
+. /etc/profile.d/rvm.sh
+
 prog="display"
 pidfile="/var/run/display.pid"
 progcmd="/opt/oneops/start-display.sh"

--- a/oneops-packer/script/oneops/oneops-setup.sh
+++ b/oneops-packer/script/oneops/oneops-setup.sh
@@ -1,6 +1,8 @@
 
 echo '==> Configuring OneOps for vagrant'
 
+source /etc/profile.d/rvm.sh
+
 mkdir -p /home/oneops
 
 mv /tmp/oneops-continuous.tar.gz /home/oneops/oneops-continuous.tar.gz

--- a/oneops-packer/script/oneops/ruby.sh
+++ b/oneops-packer/script/oneops/ruby.sh
@@ -8,12 +8,27 @@ then
 	echo 'gem: --no-document' >> /root/.gemrc
 fi
 
-yum -y install ruby-devel
+# install rvm since most distro has older version of ruby
 
-gem update --system 2.6.1
-gem install json -v 1.8.3
+curl -sSL https://rvm.io/mpapis.asc | gpg --import -
+
+curl -L get.rvm.io | bash -s stable
+
+source /etc/profile.d/rvm.sh
+
+rvm reload
+
+rvm requirements run
+
+# install pre-compiled ruby to save time
+rvm mount /tmp/ruby-2.3.3.tar.bz2
+
+rvm use 2.3.3 --default
+
+#gem update --system 2.6.1
+gem install json -v 1.8.6
 gem install bundler
 gem install rake
-gem install net-ssh -v 2.9.1
+gem install net-ssh -v 2.6.5
+gem install net-ssh-gateway -v 1.3.0 # this is the last version that can use net-ssh 2.6.5s
 gem install mixlib-log -v '1.6.0'
-echo "export PATH=$PATH:/usr/local/bin" > /etc/profile.d/gem_bin.sh


### PR DESCRIPTION
1.  Addressed the version contrainst of ruby > 2.0.0 due to activeresource 4.0.0
    Fixed the issue by installing RVM and use Ruby 2.3.3 to be compatible with
current gems setup.
    Also packaged precompiled Ruby 2.3.3 for centos 7 x86_64 to optimize the
time needed to install Ruby from 5+ minutes to ~ 30 seconds.
2.  Modified several scripts to use RVM instead of default system Ruby.
3.  Installed gem net-ssh-gateway 1.3.0 to prevent the latest version which is
incompatible with net-ssh 2.6.5