### PR TITLE
Add the oneops-packer module in a profile

### DIFF
--- a/oneops-packer/pom.xml
+++ b/oneops-packer/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.oneops</groupId>
     <artifactId>oneops-parent</artifactId>
-    <version>1.0.5-SNAPSHOT</version>
+    <version>17.06.07-09-SNAPSHOT</version>
   </parent>
   <groupId>com.oneops</groupId>
   <artifactId>oneops-packer</artifactId>
@@ -19,50 +19,55 @@
       <type>tar.gz</type>
     </dependency>
   </dependencies>
-  <build>
-    <plugins>
-      <plugin>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <executions>
-          <execution>
-            <phase>generate-resources</phase>
-            <goals>
-              <goal>copy-dependencies</goal>
-            </goals>
-            <configuration>
-              <outputDirectory>${project.build.directory}</outputDirectory>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.oneops</groupId>
-                  <artifactId>distribution</artifactId>
-                  <version>${project.version}</version>
-                  <classifier>oneops</classifier>
-                  <type>tar.gz</type>
-                </artifactItem>
-              </artifactItems>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>1.6.0</version>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-            <configuration>
-              <executable>./build.sh</executable>
-              <arguments>
-                <argument>${basedir}/target/distribution-${project.version}-oneops.tar.gz</argument>
-              </arguments>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
+  <profiles>
+    <profile>
+      <id>vagrant</id>        
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <executions>
+              <execution>
+                <phase>generate-resources</phase>
+                <goals>
+                  <goal>copy-dependencies</goal>
+                </goals>
+                <configuration>
+                  <outputDirectory>${project.build.directory}</outputDirectory>
+                  <artifactItems>
+                    <artifactItem>
+                      <groupId>com.oneops</groupId>
+                      <artifactId>distribution</artifactId>
+                      <version>${project.version}</version>
+                      <classifier>oneops</classifier>
+                      <type>tar.gz</type>
+                    </artifactItem>
+                  </artifactItems>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <version>1.6.0</version>
+            <executions>
+              <execution>
+                <phase>package</phase>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
+                <configuration>
+                  <executable>./build.sh</executable>
+                  <arguments>
+                    <argument>${basedir}/target/distribution-${project.version}-oneops.tar.gz</argument>
+                  </arguments>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,7 @@
     <module>oneops-distribution</module>
     <module>oneops-admin</module>
     <module>db-schema</module>
+    <module>oneops-packer</module>
   </modules>
   <dependencyManagement>
     <dependencies>
@@ -798,5 +799,5 @@
       </plugin>
     </plugins>
   </build>
-  
+
 </project>


### PR DESCRIPTION
Building the vagrant image with packer takes too long to be part of the normal build, but it's reasonable
for the vagrant image to be built once a day by CI or on demand by those that want to use it.

To run the build where the vagrant image is build use the following:

`mvn clean package -Pvagrant`