### PR TITLE
Simplify vagrant box build along with instructions

### DIFF
--- a/oneops-packer/README.md
+++ b/oneops-packer/README.md
@@ -1,64 +1,20 @@
 # OneOps Vagrant
 
-[packer.io](https://www.packer.io/) + [OneOps Build](https://github.com/oneops/oneops) = OneOps Single Stand Alone Instance
-
-## Requirements
-
-The following tools are required for building OneOps Vagrant box:
-
-- git
-- JDK 8
-- Ruby
-- [Packer][1] . If you have downloaded the binary, `packer` has to be added to
-  the system path(export PATH=PATH_TO_PACKER:$PATH).
-
-## Initial Setup
-
-The Vagrant process depends on the full build being run, but the Vagrant image is not built by default in the main build because it takes 10+ minutes. Make sure from the main build you have at least run `mvn clean package`. This will ensure artifacts required by the Vagrant build are in place.
-
-## Building
-
-You can use Maven to build the Vagrant box:
-
-`mvn clean package`
-
-Alternatively you can use the `build.sh` script that Maven uses directly:
-
-`./build.sh`
-
-Once the OneOps Vagrant box is created, you and added it to your collection of boxes:
+You need to have [Packer][1] installed. We assume you can figure that out by yourself. Once you have Packer installed you can run the build from the top-level directory using:
 
 ```
-vagrant box add -f --name oneops target/oneops-centos73-${version}.box
+mvn clean package -Pvagrant
 ```
 
-This will place the just created box in ~/.vagrant.d/boxes
+The Vagrant process takes 10+ minutes so it's not run as part of the default Maven build. As long as you've run `mvn clean package` from the top-level directory you can run the `./build.sh` script to build the Vagrant box.
 
-You need a Vagrantfile that looks like this:
+Once the process is finished the Vagrant box will be installed in `~/.vagrant.d/boxes` for you and the `~/.oneops/vagrant` directory will be ready to use with standard Vagrant commands.
 
 ```
-Vagrant.configure(2) do |config|
-
- config.vm.box = "oneops"
-
- # Use the vagrant-cachier plugin, if installed, to cache downloaded packages
-  if Vagrant.has_plugin?("vagrant-cachier")
-    config.cache.scope = :box
-  end
-
-  config.vm.network "forwarded_port", guest: 3001, host: 3003
-  config.vm.network "forwarded_port", guest: 3000, host: 9090
-  config.vm.network "forwarded_port", guest: 8080, host: 9091
-  config.vm.network "forwarded_port", guest: 8161, host: 8166
-
- config.vm.provider "virtualbox" do |vb|
-   vb.gui = false
-   vb.memory = 6144
-   vb.customize ["modifyvm", :id, "--cpuexecutioncap", "70"]
-  end
-end
+cd ~/.oneops/vagrant
+vagrant up
 ```
 
-And then you can use standard Vagrant commands to start the VM.s
+The OneOps box will boot and be ready for you to use.
 
 [1]: https://www.packer.io

--- a/oneops-packer/build.sh
+++ b/oneops-packer/build.sh
@@ -6,7 +6,7 @@ export ONEOPS_VERSION=$(mvn help:evaluate -Dexpression=project.version|grep -v '
 
 if [ -z $ONEOPS_ARCHIVE ]
 then
-  ONEOPS_ARCHIVE=../oneops-distribution/target/oneops-${ONEOPS_VERSION}.tar.gz
+  ONEOPS_ARCHIVE=target/distribution-${ONEOPS_VERSION}-oneops.tar.gz
 fi
 
 if [ ! -z $ONEOPS_ARCHIVE ]
@@ -14,6 +14,10 @@ then
   # Using a -var oneops_version=${ONEOPS_VERSION} doesn't seem to work in the json
   # template so using an envar in the json template instead. JvZ
   packer build -var "oneops_artifact=${ONEOPS_ARCHIVE}" -var-file=centos73.json centos.json
+  box=`ls target/oneops-centos73-*.box`
+  vagrant box add -f --name oneops $box
+  mkdir -p ~/.oneops 
+  cp -r vagrant ~/.oneops/vagrant
 else
   echo "Cannot find the OneOps archive for Packer image: ${ONEOPS_ARCHIVE}"
 fi

--- a/oneops-packer/vagrant/Vagrantfile
+++ b/oneops-packer/vagrant/Vagrantfile
@@ -1,0 +1,20 @@
+Vagrant.configure(2) do |config|
+
+ config.vm.box = "oneops"
+
+ # Use the vagrant-cachier plugin, if installed, to cache downloaded packages
+  if Vagrant.has_plugin?("vagrant-cachier")
+    config.cache.scope = :box
+  end
+
+  config.vm.network "forwarded_port", guest: 3001, host: 3003
+  config.vm.network "forwarded_port", guest: 3000, host: 9090
+  config.vm.network "forwarded_port", guest: 8080, host: 9091
+  config.vm.network "forwarded_port", guest: 8161, host: 8166
+
+ config.vm.provider "virtualbox" do |vb|
+   vb.gui = false
+   vb.memory = 6144
+   vb.customize ["modifyvm", :id, "--cpuexecutioncap", "70"]
+  end
+end


### PR DESCRIPTION
After the build the Vagrant box will be ready for the user in ~/.oneops/vagrant