### PR TITLE
rollback open release if environment design pull failed due to a missing service(s)

### DIFF
--- a/transistor/src/main/java/com/oneops/transistor/service/ManifestAsyncProcessor.java
+++ b/transistor/src/main/java/com/oneops/transistor/service/ManifestAsyncProcessor.java
@@ -18,6 +18,7 @@
 package com.oneops.transistor.service;
 
 import com.oneops.cms.exceptions.CmsBaseException;
+import com.oneops.cms.util.CmsError;
 import org.apache.log4j.Logger;
 
 import java.util.List;
@@ -55,6 +56,10 @@ public class ManifestAsyncProcessor {
                     } catch (CmsBaseException e) {
                         logger.error("CmsBaseException occurred", e);
                         envMsg = EnvSemaphore.MANIFEST_ERROR + e.getMessage();
+                        // if services are missing, design pull cannot be completed, so we have to delete all previously created rfcs and release
+                        if (e.getErrorCode()== CmsError.TRANSISTOR_MISSING_CLOUD_SERVICES) {
+                            manifestManager.rollbackOpenRelease(envId);
+                        }
                         throw e;
                     } finally {
                         envSemaphore.unlockEnv(envId, envMsg, processId);//error in design pull

--- a/transistor/src/main/java/com/oneops/transistor/service/ManifestManager.java
+++ b/transistor/src/main/java/com/oneops/transistor/service/ManifestManager.java
@@ -43,4 +43,5 @@ public interface ManifestManager {
         return threadName + "-env-" + envId;
     }
 
+    void rollbackOpenRelease(long envId);
 }

--- a/transistor/src/main/java/com/oneops/transistor/service/ManifestManagerImpl.java
+++ b/transistor/src/main/java/com/oneops/transistor/service/ManifestManagerImpl.java
@@ -567,6 +567,15 @@ public class ManifestManagerImpl implements ManifestManager {
 		manifestRfcProcessor.updatePlatfomCloudStatus(cloudRel, userId);
 	}
 
+	@Override
+	public void rollbackOpenRelease(long envId) {
+		CmsCI env = getEnv(envId);
+		String nsPath = getManifestNsPath(env);
+		List<CmsRelease> list = rfcProcessor.getLatestRelease(nsPath, "open");
+		if (list.size()>0) {
+			rfcProcessor.deleteRelease(list.get(0).getReleaseId());
+		}
+	}
 
 	private class ManifestRfcProcessorTask implements Callable<DesignCIManifestRfcTouple> {
         private final CmsCI env;


### PR DESCRIPTION
Since we pull design per platform off thread, rollback doesn't happen in case of exception, so we have to manually rollback to avoid being stuck with inconsistent release.