### PR TITLE
Changing check process count script to add support for windows

### DIFF
--- a/oneops-admin/lib/shared/cookbooks/monitor/files/default/check_process_count.sh
+++ b/oneops-admin/lib/shared/cookbooks/monitor/files/default/check_process_count.sh
@@ -1,5 +1,16 @@
 #!/bin/bash
 PROCESS=$1
+
+if [[ `uname` == *CYGWIN* ]]; then
+  out=`powershell "(get-service $PROCESS).Status"`
+  if [[ "$out" == *Stopped* ]]; then
+	 echo "$PROCESS Count |count=0"
+  else
+     echo "$PROCESS Count |count=100"
+  fi
+  exit
+fi
+
 out=`ps auxwww|egrep $PROCESS| grep -v grep| grep -v check_process_count | wc -l`
 echo $out
 echo "$PROCESS Count |count=$out"


### PR DESCRIPTION
This PR is making changes to check_process_count.sh. Adding support for windows service checks to ensure monitors work in a similar way as linux.