### PR TITLE
Rest-client gem is being implicitly installed when Chef-client 11 is …

### DIFF
--- a/oneops-admin/lib/shared/exec-gems.yaml
+++ b/oneops-admin/lib/shared/exec-gems.yaml
@@ -113,6 +113,9 @@ chef-12.11.18:
       - ffi-yajl
       - 2.2.3
     -
+      - rest-client
+      - 1.6.7
+    -
       - ms_rest
       - 0.1.1
     -


### PR DESCRIPTION
…installed, as chef 11 depends on it.

But Chef-client 12 does not have that dependency, and as this gem is being used by different cookbooks we have to install it explicitly