### PR TITLE
workorder search updated to only pull complete WO from ES

### DIFF
--- a/search/src/main/java/com/oneops/search/msg/processor/CIMessageProcessor.java
+++ b/search/src/main/java/com/oneops/search/msg/processor/CIMessageProcessor.java
@@ -128,7 +128,7 @@ public class CIMessageProcessor implements MessageProcessor {
             try {
                 SearchResponse response = client.prepareSearch("cms-2*")
                         .setTypes("workorder")
-                        .setQuery(queryStringQuery(String.valueOf(ciId)).field("rfcCi.ciId"))
+                        .setQuery(queryStringQuery("rfcCi.ciId:"+ciId+" AND dpmtRecordState:complete"))
                         .addSort("searchTags.responseDequeTS", SortOrder.DESC)
                         .setSize(1)
                         .execute()

--- a/search/src/main/java/com/oneops/search/msg/processor/CIMessageProcessor.java
+++ b/search/src/main/java/com/oneops/search/msg/processor/CIMessageProcessor.java
@@ -17,9 +17,6 @@
  *******************************************************************************/
 package com.oneops.search.msg.processor;
 
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
 import com.oneops.cms.cm.domain.CmsCI;
 import com.oneops.cms.simple.domain.CmsCISimple;
 import com.oneops.cms.simple.domain.CmsWorkOrderSimple;
@@ -30,15 +27,13 @@ import com.oneops.search.msg.processor.ci.DeploymentPlanProcessor;
 import com.oneops.search.msg.processor.ci.PolicyProcessor;
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
+import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.search.sort.SortOrder;
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-
-import java.util.HashMap;
-import java.util.Map;
 
 import static org.elasticsearch.index.query.QueryBuilders.queryStringQuery;
 
@@ -104,7 +99,7 @@ public class CIMessageProcessor implements MessageProcessor {
 
         //add wo to all bom cis
         if (ci.getCiClassName().startsWith("bom")) {
-            message = this.process(simpleCI);
+            message = this.processBomCI(simpleCI);
         } else {
             message = GSON_ES.toJson(simpleCI);
         }
@@ -119,7 +114,7 @@ public class CIMessageProcessor implements MessageProcessor {
      * @param ci
      * @return
      */
-    private String process(CmsCISimple ci) {
+    private String processBomCI(CmsCISimple ci) {
         CmsCISearch ciSearch = new CmsCISearch();
         BeanUtils.copyProperties(ci, ciSearch);
         long ciId = ciSearch.getCiId();
@@ -150,6 +145,11 @@ public class CIMessageProcessor implements MessageProcessor {
         }
         if (wos == null) {
             logger.info("WO not found for ci " + ci.getCiId() + " of type " + ci.getCiClassName());
+            GetResponse response = client.prepareGet(indexer.getIndexName(), "ci", ""+ci.getCiId()).get();
+            if (response.isExists()){
+                wos = GSON.fromJson(GSON.toJson(response.getSource().get("workorder")), CmsWorkOrderSimple.class);
+                ciSearch.setWorkorder(wos);
+            }
         }
         return GSON_ES.toJson(ciSearch);
     }

--- a/search/src/main/java/com/oneops/search/msg/processor/WorkorderMessageProcessor.java
+++ b/search/src/main/java/com/oneops/search/msg/processor/WorkorderMessageProcessor.java
@@ -1,0 +1,62 @@
+package com.oneops.search.msg.processor;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.oneops.search.msg.index.Indexer;
+import org.apache.log4j.Logger;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.search.sort.SortOrder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.elasticsearch.index.query.QueryBuilders.queryStringQuery;
+
+@Service
+public class WorkorderMessageProcessor implements MessageProcessor {
+
+    private static Logger logger = Logger.getLogger(WorkorderMessageProcessor.class);
+    @Autowired
+    private Indexer indexer;
+    @Autowired
+    private Client client;
+
+    @Override
+    public void processMessage(String message, String msgType, String msgId) {
+
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode rootNode = null;
+        try {
+            rootNode = mapper.readValue(message, JsonNode.class);
+
+            JsonNode rfcCi = rootNode.get("rfcCi");
+            if (rfcCi != null && rfcCi.get("rfcAction") != null && rfcCi.get("rfcAction").asText().equals("delete")) {
+                SearchResponse response = client.prepareSearch("cms-2*")
+                        .setTypes("workorder")
+                        .setQuery(queryStringQuery("rfcCi.ciId:" + rfcCi.get("ciId") + " AND dpmtRecordState:complete"))
+                        .addSort("searchTags.responseDequeTS", SortOrder.DESC)
+                        .setSize(1)
+                        .execute()
+                        .actionGet();
+
+                if (response.getHits().getHits().length > 0) {
+                    Map<String, Object> map = response.getHits().getHits()[0].getSource();
+                    Map<String, Object> payLoad = (Map<String, Object>) map.get("payLoad");
+                    if (payLoad != null && payLoad.get("offerings") != null) {
+                        JsonNode offeringsContent = mapper.readValue(GSON.toJson(payLoad.get("offerings")), JsonNode.class);
+                        ((ObjectNode)rootNode.get("payLoad")).put("offerings", offeringsContent);
+                        message = mapper.writeValueAsString(rootNode);
+                    }
+                }
+            }
+        } catch (Exception e) {
+            logger.warn(e, e);
+        }
+        indexer.index(msgId, msgType, message);
+    }
+
+}

--- a/search/src/main/java/com/oneops/search/msg/processor/es/ESMessageProcessor.java
+++ b/search/src/main/java/com/oneops/search/msg/processor/es/ESMessageProcessor.java
@@ -53,6 +53,8 @@ public class ESMessageProcessor implements MessageProcessor {
     private ReleaseMessageProcessor releaseMessageProcessor;
     @Autowired
     private NotificationMessageProcessor notificationMessageProcessor;
+    @Autowired
+    private WorkorderMessageProcessor workorderMessageProcessor;
 
     @Autowired
     private Indexer indexer;
@@ -93,6 +95,9 @@ public class ESMessageProcessor implements MessageProcessor {
                     break;
                 case "notification":
                     notificationMessageProcessor.processMessage(message, msgType, msgId);
+                    break;
+                case "workorder":
+                    workorderMessageProcessor.processMessage(message, msgType, msgId);
                     break;
                 default:
                     indexer.index(msgId, msgType, message);


### PR DESCRIPTION
to avoid pulling WO without offerings in some cases. 

Added two more fixes: 
- additional search for workorder in existing CIs is workorder is missing from wo index, because we only keep last 6 months of weekly indexes.
- in case of workorder action "delete" fetch and store offerings from last workorder to assist with cost calculations (new WorkorderMessageProcessor added)