### PR TITLE
Fixed issue where "shared" library in oneops-admin is missing metadata.rb.

### DIFF
--- a/oneops-admin/lib/shared/cookbooks/shared/metadata.rb
+++ b/oneops-admin/lib/shared/cookbooks/shared/metadata.rb
@@ -1,0 +1,7 @@
+name 'Shared'
+description 'Shared library'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version '0.1'
+maintainer 'OneOps'
+maintainer_email 'support@oneops.com'
+license 'Copyright OneOps, All rights reserved.'


### PR DESCRIPTION
This commit is to address the issue where shared is missing metadata.rb.

The omission of this metadata.rb has created an issue where Berksfile and
various other tools are unable to process this library as cookbook.

The "shared" cookbook in questions is hosted at https://github.com/oneops/oneops.git,
under oneops-admin/lib/shared/cookbooks/shared. The codebase oneops-admin eventually
packaged as oneops-admin-{VERSION} .gem and installed part of inductor.
The only part of the code that needs to be sync to cms is under lib/base.
The main lib/shared is part of a wrapper script to launch workorder thus has no relation to cms.
The rest of the shared collections: artifact,attachment,log,monitor,security,and simple_iptables all have metadata.rb.
The best explanation is that "shared" wasn't meant to use as a cookbook but more loosely as "monkey_patch" existing chef/ruby behavior.