### PR TITLE
changing the unibuild directory

### DIFF
--- a/oneops-packer/build.sh
+++ b/oneops-packer/build.sh
@@ -16,8 +16,8 @@ then
   packer build -var "oneops_artifact=${ONEOPS_ARCHIVE}" -var-file=centos73.json centos.json
   box=`ls target/oneops-centos73-*.box`
   vagrant box add -f --name oneops $box
-  mkdir -p ~/.oneops 
-  cp -r vagrant ~/.oneops/vagrant
+  mkdir -p ~/.oneopsuni 
+  cp -r vagrant ~/.oneopsuni/vagrant
 else
   echo "Cannot find the OneOps archive for Packer image: ${ONEOPS_ARCHIVE}"
 fi


### PR DESCRIPTION
if admin oneops cli installed in host , the  .oneops  file already created , due to this uni build was failing, so renamed the directory to ~/.oneopsuni  to resolve the conflicts.