### PR TITLE
Modified oneops-admin.gem to include dot file.

### DIFF
--- a/oneops-admin/oneops-admin.gemspec
+++ b/oneops-admin/oneops-admin.gemspec
@@ -50,5 +50,5 @@ Gem::Specification.new do |s|
   s.add_dependency "fog-aliyun", '= 0.1.0'
   s.bindir       = 'bin'
   s.require_path = 'lib'
-  s.files        = %w() + ["oneops-admin.gemspec"] + ["Gemfile"] + Dir.glob(".chef/**/*") + Dir.glob("lib/**/*") + ["#{Inductor::JAR}"] + Dir.glob('bin/**/*')
+  s.files        = %w() + ["oneops-admin.gemspec"] + ["Gemfile"] + Dir.glob(".chef/**/*") + Dir.glob("lib/**/*", File::FNM_DOTMATCH).reject { |f| f =~ /\.$/ || f =~ /\.\.$/ } + ["#{Inductor::JAR}"] + Dir.glob('bin/**/*')
 end


### PR DESCRIPTION
    Modified oneops-admin.gem to include dot file. By default Dir.glob will exclude
    files/directories that start with '.'.  This change ensure that it will pick up
    files/directories in that category.
    
    Modified to use File::FNM_DOTMATCH that will turn on DOT match, and also add in
    reject to exclude '.' and '..' file.
   
   This is needed to include .ignore file to be ignore during model sync.
