### PR TITLE
Change cookbook_path array order.

### DIFF
--- a/inductor/src/main/java/com/oneops/inductor/AbstractOrderExecutor.java
+++ b/inductor/src/main/java/com/oneops/inductor/AbstractOrderExecutor.java
@@ -325,10 +325,8 @@ public abstract class AbstractOrderExecutor {
         String sharedDir = config.getCircuitDir().replace("packer",
                 "shared/cookbooks");
 
-        Set<String> cookbookPaths = new HashSet<>();
-        cookbookPaths.add(cookbookDir);
-        cookbookPaths.add(sharedDir);
-        
+        Set<String> cookbookPaths = new LinkedHashSet<>();
+
         if (cloudServices != null) {
         	for (String serviceName : cloudServices.keySet()) { // for each service
         		CmsCISimple serviceCi = cloudServices.get(serviceName).get(cloudName);
@@ -341,6 +339,13 @@ public abstract class AbstractOrderExecutor {
         		}
         	}
         }
+        if (cookbookPaths.size() > 0) {
+            //Remove the current component's circuit from the cookbook_path so that we can add it after other circuits
+            //This is to make sure the current component's circuit is higher priority in search path
+            cookbookPaths.remove(cookbookDir);
+        }
+        cookbookPaths.add(cookbookDir);
+        cookbookPaths.add(sharedDir);
         String content = "cookbook_path " + gson.toJson(cookbookPaths) + "\n";
 
         content += "lockfile \"" + filename + ".lock\"\n";

--- a/inductor/src/main/java/com/oneops/inductor/AbstractOrderExecutor.java
+++ b/inductor/src/main/java/com/oneops/inductor/AbstractOrderExecutor.java
@@ -316,36 +316,8 @@ public abstract class AbstractOrderExecutor {
     		Map<String, Map<String, CmsCISimple>> cloudServices, String logLevel) {
         String filename = "/tmp/chef-" + ci;
 
-        String cookbookDir = config.getCircuitDir();
-        if (!cookbookRelativePath.equals(""))
-            cookbookDir = config.getCircuitDir().replace("packer",
-                    cookbookRelativePath);
+        Set<String> cookbookPaths = createCookbookSearchPath(cookbookRelativePath, cloudServices, cloudName);
 
-        cookbookDir += "/components/cookbooks";
-        String sharedDir = config.getCircuitDir().replace("packer",
-                "shared/cookbooks");
-
-        Set<String> cookbookPaths = new LinkedHashSet<>();
-
-        if (cloudServices != null) {
-        	for (String serviceName : cloudServices.keySet()) { // for each service
-        		CmsCISimple serviceCi = cloudServices.get(serviceName).get(cloudName);
-        		if (serviceCi != null) {
-        			String serviceClassName = serviceCi.getCiClassName();
-        	        String serviceCookbookCircuit = getCookbookPath(serviceClassName);
-        	        if (! serviceCookbookCircuit.equals(cookbookRelativePath)) { 
-        	        	cookbookPaths.add(config.getCircuitDir().replace("packer", serviceCookbookCircuit) + "/components/cookbooks");
-        	        }
-        		}
-        	}
-        }
-        if (cookbookPaths.size() > 0) {
-            //Remove the current component's circuit from the cookbook_path so that we can add it after other circuits
-            //This is to make sure the current component's circuit is higher priority in search path
-            cookbookPaths.remove(cookbookDir);
-        }
-        cookbookPaths.add(cookbookDir);
-        cookbookPaths.add(sharedDir);
         String content = "cookbook_path " + gson.toJson(cookbookPaths) + "\n";
 
         content += "lockfile \"" + filename + ".lock\"\n";
@@ -372,6 +344,43 @@ public abstract class AbstractOrderExecutor {
                     + e.getMessage());
         }
         return filename;
+    }
+
+    protected LinkedHashSet<String> createCookbookSearchPath(String cookbookRelativePath,
+                                                   Map<String, Map<String, CmsCISimple>> cloudServices,
+                                                   String cloudName) {
+        String cookbookDir = config.getCircuitDir();
+        if (!cookbookRelativePath.equals(""))
+            cookbookDir = config.getCircuitDir().replace("packer",
+                    cookbookRelativePath);
+
+        cookbookDir += "/components/cookbooks";
+        String sharedDir = config.getCircuitDir().replace("packer",
+                "shared/cookbooks");
+
+        LinkedHashSet<String> cookbookPaths = new LinkedHashSet<>();
+
+        if (cloudServices != null) {
+            for (String serviceName : cloudServices.keySet()) { // for each service
+                CmsCISimple serviceCi = cloudServices.get(serviceName).get(cloudName);
+                if (serviceCi != null) {
+                    String serviceClassName = serviceCi.getCiClassName();
+                    String serviceCookbookCircuit = getCookbookPath(serviceClassName);
+                    if (! serviceCookbookCircuit.equals(cookbookRelativePath)) {
+                        cookbookPaths.add(config.getCircuitDir().replace("packer", serviceCookbookCircuit)
+                                + "/components/cookbooks");
+                    }
+                }
+            }
+        }
+        if (cookbookPaths.size() > 0) {
+            //Remove the current component's circuit from the cookbook_path so that we can add it after other circuits
+            //This is to make sure the current component's circuit is higher priority in search path
+            cookbookPaths.remove(cookbookDir);
+        }
+        cookbookPaths.add(cookbookDir);
+        cookbookPaths.add(sharedDir);
+        return cookbookPaths;
     }
 
     /**

--- a/inductor/src/main/java/com/oneops/inductor/Config.java
+++ b/inductor/src/main/java/com/oneops/inductor/Config.java
@@ -497,6 +497,10 @@ public class Config {
 		this.env = env;
 	}
 
+	public void setCircuitDir(String circuitDir) {
+		this.circuitDir = circuitDir;
+	}
+
 	/**
 	 * Get the env vars key-value map.
 	 *


### PR DESCRIPTION
Modify the cookbook_path of chef execution so that the current component's circuit appears after the cloud-service's circuits. 
Chef looks to be overriding the cookbook path with the ones found in later directories specificied in the cookbook_path array. This causes issues in some cases. This change makes sure the circuit of the component being deployed gets higher priority in the search.

Also added test code and corresponding code refactor to be able to test the code