### PR TITLE
changes to fix issue with inductor.add

### DIFF
--- a/oneops-admin/lib/inductor.rb
+++ b/oneops-admin/lib/inductor.rb
@@ -1,4 +1,5 @@
 require 'thor'
+require 'json'
 
 class Inductor < Thor
   include Thor::Actions


### PR DESCRIPTION
why do we need `json` back into `inductor.rb`?
this line https://github.com/oneops/oneops/blob/master/oneops-admin/lib/inductor.rb#L19 copies the files from `templates/cloud` to the `inductor` directory on the inductor machine. 
and one of those files is this `.tt` file - https://github.com/oneops/oneops/blob/master/oneops-admin/lib/templates/cloud/logstash-forwarder/conf/logstash-forwarder.conf.tt

This `tt` has embedded ruby and before copying this file to destination `thor` uses `erb` to execute this template and copy the resulting file. and this line https://github.com/oneops/oneops/blob/master/oneops-admin/lib/templates/cloud/logstash-forwarder/conf/logstash-forwarder.conf.tt#L17 is using `to_json` on a ruby `array`. 
to enable `to_json` on arrays we need to bring in `json` library in to the code file, which is `inductor.rb` here. so I believe removing that ‘json’ from inductor.rb caused this failure. I have added it back and tested now the `inductor add` is successful