### PR TITLE
changes to install ruby 2.0, oneops-admin-adapter, oneops-admin-induc…

### DIFF
--- a/oneops-packer/centos.json
+++ b/oneops-packer/centos.json
@@ -76,6 +76,11 @@
       "destination": "/tmp/ruby-2.3.3.tar.bz2"
     },
     {
+      "type": "file",
+      "source": "files/ruby/binaries/centos/7/x86_64/ruby-2.0.0-p648.tar.bz2",
+      "destination": "/tmp/ruby-2.0.0-p648.tar.bz2"
+    },
+    {
       "environment_vars": [
         "CM={{user `cm`}}",
         "CM_VERSION={{user `cm_version`}}",

--- a/oneops-packer/script/oneops/oneops-setup.sh
+++ b/oneops-packer/script/oneops/oneops-setup.sh
@@ -55,6 +55,9 @@ sed -i 's/service.*start/systemctl start tomcat/' deploy_java.sh
 sed -i 's/cp.*dist.*dist.*search.*jar/cp $OO_HOME\/dist\/search.jar \/opt\/oneops-search/' deploy_search.sh
 sed -i 's/gem install.*oneops-admin.*/gem install $OO_HOME\/dist\/oneops-admin-1.0.0.gem --no-ri --no-rdoc/' deploy_ooadmin.sh
 
+sed -i 's/gem install.*oneops-admin.*/gem install $OO_HOME\/dist\/oneops-admin-adapter-1.0.0.gem --no-ri --no-rdoc/' deploy_ooadmin.sh
+sed -i '/gem install $OO_HOME\/dist\/oneops-admin-adapter-1.0.0.gem --no-ri --no-rdoc/a gem install $OO_HOME/dist/oneops-admin-inductor-az-1.0.0.gem --no-ri --no-rdoc' deploy_ooadmin.sh
+
 chmod a+x /etc/init.d/display
 
 ./oneops_build.sh "$@"

--- a/oneops-packer/script/oneops/ruby.sh
+++ b/oneops-packer/script/oneops/ruby.sh
@@ -1,6 +1,8 @@
 
 echo '==> Configuring ruby for vagrant'
 
+sudo yum install -y ruby ruby-devel gcc gcc-c++ libxml2-devel libxslt-devel
+
 grep -s -i 'no-document' /root/.gemrc
 
 if [ $? -ne 0 ];
@@ -22,8 +24,9 @@ rvm requirements run
 
 # install pre-compiled ruby to save time
 rvm mount /tmp/ruby-2.3.3.tar.bz2
+rvm mount /tmp/ruby-2.0.0-p648.tar.bz2
 
-rvm use 2.3.3 --default
+rvm use 2.0.0 --default
 
 #gem update --system 2.6.1
 gem install json -v 1.8.6


### PR DESCRIPTION
changes 
- installed ruby 2.0 
- made ruby 2.0 as default 
- since oneops-admin is now split in to adapter and inductor gems, now I am installing oneops-admin-adapter.gem and oneops-admin-inductor.gem instead of oneops-admin.gem 