### PR TITLE
Refactor vagrant setup to not use rvm.  Refactor ooadmin deployment script.

### DIFF
--- a/oneops-packer/centos73.json
+++ b/oneops-packer/centos73.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Build with `packer build -var-file=centos73.json centos.json`",
   "vm_name": "centos73",
-  "cpus": "1",
+  "cpus": "4",
   "disk_size": "65536",
   "iso_checksum": "c018577c75b2434fbb2c324789dee0ba887d9c32",
   "iso_checksum_type": "sha1",

--- a/oneops-packer/script/oneops/oneops-setup.sh
+++ b/oneops-packer/script/oneops/oneops-setup.sh
@@ -1,15 +1,16 @@
 
 echo '==> Configuring OneOps for vagrant'
 
-source /etc/profile.d/rvm.sh
-
 mkdir -p /home/oneops
 
 mv /tmp/oneops-continuous.tar.gz /home/oneops/oneops-continuous.tar.gz
 
 cd /home/oneops
 
-tar zxvf oneops-continuous.tar.gz -C /home/
+tar zxf oneops-continuous.tar.gz -C /home/
+
+mkdir -p /home/oneops/dist/oneops-admin-inductor && tar zxf /home/oneops/dist/oneops-admin-*-inductor.tar.gz -C /home/oneops/dist/oneops-admin-inductor
+mkdir -p /home/oneops/dist/oneops-admin-adapter && tar zxf /home/oneops/dist/oneops-admin-*-adapter.tar.gz -C /home/oneops/dist/oneops-admin-adapter
 
 export BUILD_BASE='/home/oneops/build'
 export OO_HOME='/home/oneops'
@@ -53,7 +54,83 @@ sed -i 's/cp.*OO_HOME\/dist\/oneops\/dist.*war.*webapps/cp $OO_HOME\/dist\/\*\.w
 sed -i 's/service.*stop/systemctl stop tomcat/' deploy_java.sh
 sed -i 's/service.*start/systemctl start tomcat/' deploy_java.sh
 sed -i 's/cp.*dist.*dist.*search.*jar/cp $OO_HOME\/dist\/search.jar \/opt\/oneops-search/' deploy_search.sh
-sed -i 's/gem install.*oneops-admin.*/gem install $OO_HOME\/dist\/oneops-admin-1.0.0.gem --no-ri --no-rdoc/' deploy_ooadmin.sh
+
+cat > deploy_ooadmin.sh <<EOL
+#!/bin/sh
+
+echo "Deploying OneOps Admin "
+
+cd $OO_HOME/dist/oneops-admin-inductor
+gem install oneops-admin-inductor-1.0.0.gem --ignore-dependencies --no-ri --no-rdoc
+bundle install --gemfile=oneops-admin-inductor.gemfile --local
+
+cd $OO_HOME/dist/oneops-admin-adapter
+gem install oneops-admin-adapter-1.0.0.gem --ignore-dependencies --no-ri --no-rdoc
+bundle install --gemfile=oneops-admin-adapter.gemfile --local
+
+mkdir -p /opt/oneops-admin
+cd /opt/oneops-admin
+
+export CIRCUIT_LOCAL_ASSET_STORE_ROOT=/opt/oneops/app/public/_circuit
+
+rm -fr circuit
+circuit init
+
+cd "$BUILD_BASE"
+
+if [ -d "$BUILD_BASE/circuit-oneops-1" ]; then
+  echo "doing git pull on circuit-oneops-1"
+  cd "$BUILD_BASE/circuit-oneops-1"
+  git pull
+else
+  echo "doing git clone"
+  git clone "$GITHUB_URL/circuit-oneops-1.git"
+fi
+sleep 2
+
+cd "$BUILD_BASE/circuit-oneops-1"
+circuit install
+
+echo "install inductor as ooadmin"
+adduser ooadmin 2>/dev/null
+
+cd /opt/oneops
+chown ooadmin /opt/oneops
+su ooadmin -c "
+inductor create
+cd inductor
+# add inductor using shared queue
+inductor add --mqhost localhost \
+--dns on \
+--debug on \
+--daq_enabled true \
+--collector_domain localhost \
+--tunnel_metrics on \
+--perf_collector_cert /etc/pki/tls/logstash/certs/logstash-forwarder.crt \
+--ip_attribute public_ip \
+--queue shared \
+--mgmt_url http://localhost:9090 \
+--logstash_cert_location /etc/pki/tls/logstash/certs/logstash-forwarder.crt \
+--logstash_hosts vagrant.oo.com:5000 \
+--max_consumers 10 \
+--local_max_consumers 10 \
+--authkey superuser:amqpass \
+--amq_truststore_location /opt/oneops/inductor/lib/client.ts \
+--additional_java_args \"\" \
+--env_vars \"\"
+mkdir -p /opt/oneops/inductor/lib
+\cp /opt/activemq/conf/client.ts /opt/oneops/inductor/lib/client.ts
+ln -sf /home/oneops/build/circuit-oneops-1 .
+inductor start
+"
+inductor install_initd
+chkconfig --add inductor
+chkconfig inductor on
+echo "export INDUCTOR_HOME=/opt/oneops/inductor" > /opt/oneops/inductor_env.sh
+echo "export PATH=$PATH:/usr/local/bin" >> /opt/oneops/inductor_env.sh
+
+echo "done with inductor"
+EOL
 
 chmod a+x /etc/init.d/display
 
@@ -62,4 +139,3 @@ chmod a+x /etc/init.d/display
 if [ $? -ne 0 ]; then
   exit 1;
 fi
-

--- a/oneops-packer/script/oneops/ruby.sh
+++ b/oneops-packer/script/oneops/ruby.sh
@@ -8,27 +8,11 @@ then
 	echo 'gem: --no-document' >> /root/.gemrc
 fi
 
-# install rvm since most distro has older version of ruby
+yum -y install ruby ruby-devel rubygems
 
-curl -sSL https://rvm.io/mpapis.asc | gpg --import -
-
-curl -L get.rvm.io | bash -s stable
-
-source /etc/profile.d/rvm.sh
-
-rvm reload
-
-rvm requirements run
-
-# install pre-compiled ruby to save time
-rvm mount /tmp/ruby-2.3.3.tar.bz2
-
-rvm use 2.3.3 --default
-
-#gem update --system 2.6.1
-gem install json -v 1.8.6
-gem install bundler
-gem install rake
+gem update --system 1.8.25
+gem install json -v 1.7.7
+gem install bundler -v 1.15.4
 gem install net-ssh -v 2.6.5
 gem install net-ssh-gateway -v 1.3.0 # this is the last version that can use net-ssh 2.6.5s
 gem install mixlib-log -v '1.6.0'


### PR DESCRIPTION
Remove RVM from setup as we don't really need it.  We have standardize with Ruby 2.0.0 with is available with CentOS 7.x. Refactor deploy_ooadmin.sh to use ooadmin split gems. Bump up cpu from 1 to 4 to speed up packer building.