### PR TITLE
Fixed a bug with chunking in Artifact and Shared

### DIFF
--- a/oneops-admin/lib/shared/cookbooks/artifact/libraries/chef_rest.rb
+++ b/oneops-admin/lib/shared/cookbooks/artifact/libraries/chef_rest.rb
@@ -40,6 +40,7 @@ class Chef
     def probe_url(url)
       url_path = url.to_s
       uri = URI(url_path)
+
       ssl = uri.scheme == "https" ? true : false
       headers_h, headers = nil
       if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.0.0')
@@ -122,7 +123,6 @@ class Chef
       Chef::Log.info("Fetching in #{parts.length} parts")
       Chef::Log.info("Part details: #{pp parts.inspect}")
       # todo.. resume mode
-
       #install parallel gem, for windows make sure it installs into chef-dedicated instance of ruby
       if RUBY_PLATFORM =~ /mswin|mingw|cygwin/
         `c:\\opscode\\chef\\embedded\\bin\\gem install parallel -v 1.3.3`
@@ -136,7 +136,7 @@ class Chef
           Gem.clear_paths
         end
       end
-      
+
       require 'parallel'
 
       download_start = Time.now
@@ -157,7 +157,7 @@ class Chef
         part_file = "#{local_path}.#{part['slot']}.tmp"
         size = File.size(part_file)
         if part['end'] != ''
-          part_size = (part['slot'] + 1 == parts.length) ? part['size'] : part['size'] + 1
+          part_size = part['size']
           if size != part_size
             Chef::Log.info("slot: #{part['slot']} comparing #{part_size} == #{part['size']}   fize_size = #{size}")
             Chef::Log.warn("File: #{part_file} does not seem to complete its download, please retry and verify")
@@ -247,52 +247,47 @@ class Chef
 
     def calculate_parts(content_length, parts=10, chunk_size=1048576)
       parts_details = []
-      chunk_parts = content_length / chunk_size
 
-      if chunk_parts >= parts
+      if content_length/chunk_size < parts
+        chunk_parts = content_length / chunk_size
+
+        # The remainder will be the amount of bytes left as a percentage of the size of a part.
+        content_remainder = content_length % chunk_size # e.g. 31521931 % 10 = 1
+      else
         chunk_size = content_length / parts
         chunk_parts = parts
+
+        # The remainder will be the number of bytes left on the last part. If max parts then it would be the 11th part. part[10]
+        content_remainder = content_length % parts # e.g. 31521931 % 10 = 1
       end
 
-      content_remainder = content_length % chunk_parts # e.g. 31521931 % 10 = 1
-      byte_end = 0
+      # The -1 accounts for this being array positions.
+      chunk_size = chunk_size - 1
+      byte_start = 0
+      byte_end = byte_start + chunk_size
 
       (0..chunk_parts-1).each do |n|
-        byte_start = (n*chunk_size == 0) ? 0 : (n*chunk_size) + 1
-        byte_end = ((n*chunk_size)+chunk_size) <= content_length ? ((n*chunk_size)+chunk_size) : ''
-        if byte_end == content_length # http server doesn't like the end of range to be
-          byte_end = '' # the same as the content_length
-        end
-        byte_size = (byte_end == '') ? content_length - byte_start.to_i : byte_end.to_i - byte_start.to_i
+
+        # Start at 0 or one after the end position of the last part.
+        byte_start = (n==0) ? 0 : byte_end + 1
+
+        # End at a chunk_size distance from start.
+        byte_end = byte_start + chunk_size
+
+        # Size is the total number of bytes in this part. The + 1 accounts for the start byte.
+        byte_size = (byte_end.to_i - byte_start.to_i) + 1
+
         parts_details.push({'slot' => n, 'start' => byte_start, 'end' => byte_end, 'size' => byte_size})
       end
 
       unless (content_remainder == 0)
+        # Since content_length == last_position+1; the +1 is not needed.
         byte_start = byte_end + 1
-        byte_size = content_length - byte_start
+        byte_size = (content_length - byte_start)
 
-        if byte_start == content_length
-          parts_details[parts_details.length-1]['end'] = ''
-          parts_details[parts_details.length-1]['size'] = parts_details[parts_details.length-1]['size'] + 1
-        else
-          parts_details.push({'slot' => chunk_parts, 'start' => byte_start, 'end' => '', 'size' => byte_size})
-        end
+        parts_details.push({'slot' => chunk_parts, 'start' => byte_start, 'end' => (content_length-1), 'size' => byte_size})
       end
 
-      last_slot = parts_details.length - 1
-      last_slot_byte_end = parts_details[last_slot]['end']
-
-      if parts_details[last_slot]['end'] != '' && parts_details[last_slot]['end'] < content_length
-        byte_start = last_slot_byte_end + 1
-        size = content_length - byte_start
-
-        if byte_start == content_length
-          parts_details[last_slot-1]['end'] = ''
-          parts_details[last_slot-1]['size'] = parts_details[last_slot-1]['size'] + 1
-        else
-          parts_details.push({'slot' => last_slot + 1, 'start' => byte_start, 'end' => '', size => size})
-        end
-      end
       parts_details
     end
   end


### PR DESCRIPTION
the bug was basically that if there were 2 or less bytes leftover then it would fail. The way it would fail is that the last few bytes would create and send an invalid range to the http server. So the servers default behavior was to send back the full range. so in this case on the last call for bytes it would get the whole file. effectively giving you a file twice the size + 1  when you combined all the parts.
the bug was created by a bad assumption in the code that the number for the last byte that you would send in the range was equal to the content length. that put it off by one. there was another off by one error in how it started the download. The first part was 1 byte bigger than the other parts. that made it off by 2.


The last pr got reverted because I had left a bit of the old logic in there that clashed with the new changes if certain conditions were met. There is now no logic left in the calculate_parts function that is not mine.