### PR TITLE
Prevent deadlocks during simultaneous design pulls

### DIFF
--- a/transistor/src/main/java/com/oneops/transistor/service/ManifestAsyncProcessor.java
+++ b/transistor/src/main/java/com/oneops/transistor/service/ManifestAsyncProcessor.java
@@ -32,6 +32,11 @@ public class ManifestAsyncProcessor {
 
     private ManifestManager manifestManager;
     private EnvSemaphore envSemaphore;
+    private ExecutorService executor;
+
+    public void setExecutor(ExecutorService executor) {
+        this.executor = executor;
+    }
 
     public void setManifestManager(ManifestManager manifestManager) {
         this.manifestManager = manifestManager;
@@ -42,7 +47,7 @@ public class ManifestAsyncProcessor {
     }
 
     public long generateEnvManifest(List<Long> envIds, String userId, Map<String, String> platModes) {
-        ExecutorService executor = Executors.newSingleThreadExecutor();
+        
         String oldThreadName = Thread.currentThread().getName();
         try {
             for (long envId : envIds) {
@@ -66,7 +71,6 @@ public class ManifestAsyncProcessor {
                     }
                 });
             }
-            executor.shutdown();
         } finally {
             Thread.currentThread().setName(oldThreadName);
         }

--- a/transistor/src/main/webapp/WEB-INF/application-context.xml
+++ b/transistor/src/main/webapp/WEB-INF/application-context.xml
@@ -168,7 +168,7 @@
 
 	<bean id="designPullFixedPoolExecutor" class="java.util.concurrent.Executors"
 		  factory-method="newFixedThreadPool" destroy-method="shutdown">
-		<constructor-arg value="5"/>      
+		<constructor-arg value="${DESIGN_PULL_THREAD_POOL_CNT:5}"/>      
 		<!--It is extremely important to keep this pool size less then db connection pool size to avoid deadlocks -->
 	</bean>
 

--- a/transistor/src/main/webapp/WEB-INF/application-context.xml
+++ b/transistor/src/main/webapp/WEB-INF/application-context.xml
@@ -163,7 +163,14 @@
 	<bean id="maProcessor" class="com.oneops.transistor.service.ManifestAsyncProcessor" >
 		<property name="manifestManager" ref="manifestManager" />
         <property name="envSemaphore" ref="envSemaphore" />
+		<property name="executor" ref="designPullFixedPoolExecutor"/>
     </bean>
+
+	<bean id="designPullFixedPoolExecutor" class="java.util.concurrent.Executors"
+		  factory-method="newFixedThreadPool" destroy-method="shutdown">
+		<constructor-arg value="5"/>      
+		<!--It is extremely important to keep this pool size less then db connection pool size to avoid deadlocks -->
+	</bean>
 
 	<bean id="packRefreshProcessor" class="com.oneops.transistor.service.PackRefreshProcessor" >
 		<property name="cmProcessor" ref="cmsCmProcessor" />


### PR DESCRIPTION
For a now: limit number of simultaneous pulls to less then number of connection in db pool, eventually need to move executor from manager to processor to avoid connection locking.