### PR TITLE
 Providing support for using a custom Gemfile, specific to the cookbook

### DIFF
--- a/inductor/src/main/resources/verification/kitchen-tmpl.yml
+++ b/inductor/src/main/resources/verification/kitchen-tmpl.yml
@@ -19,6 +19,12 @@ verifier:
   name: serverspec
   remote_exec: false
   transport: local
+  test_serverspec_installed: false
+  additional_install_command: "mkdir -p <circuit_root>/gems"
+  bundler_path: 'GEM_HOME=<circuit_root>/gems /usr/local/bin'
+  gemfile: test/integration/Gemfile
+  env_vars:
+    GEM_PATH: <circuit_root>/gems:/usr/local/share/gems
 platforms:
   - name: <platform_name>
 suites:


### PR DESCRIPTION
All the required custom gems will be installed under circuit-root/gems folder
and will be re-used between different deployments.
the circuit-root/gems folder will be automatically purged when a release occurs