### PR TITLE
fixed error in circuit install for local

### DIFF
--- a/oneops-packer/files/oneops/deploy_circuits.sh
+++ b/oneops-packer/files/oneops/deploy_circuits.sh
@@ -11,7 +11,8 @@ for d in /tmp/oneops_circuits/* ; do
     cd /opt/oneops/inductor
     CIRCUIT="$(/bin/basename ${d})"
     CIRCUITS[${CIRCUIT}]=$CIRCUIT
-    mv -f ${d} /home/oneops/build
+    rm -rf /home/oneops/build/${CIRCUIT}
+    mv ${d} /home/oneops/build/
     if [ ! -L ${CIRCUIT} ]; then
       ln -s /home/oneops/build/${CIRCUIT} ${CIRCUIT}
     fi

--- a/oneops-packer/files/oneops/deploy_circuits.sh
+++ b/oneops-packer/files/oneops/deploy_circuits.sh
@@ -11,7 +11,7 @@ for d in /tmp/oneops_circuits/* ; do
     cd /opt/oneops/inductor
     CIRCUIT="$(/bin/basename ${d})"
     CIRCUITS[${CIRCUIT}]=$CIRCUIT
-    mv ${d} /home/oneops/build
+    mv -f ${d} /home/oneops/build
     if [ ! -L ${CIRCUIT} ]; then
       ln -s /home/oneops/build/${CIRCUIT} ${CIRCUIT}
     fi


### PR DESCRIPTION
If you try to include oneops circuit one to the circuits folder in oneops packer than it will fail while trying to move the files. Putting in an rm to make sure the folder is clear before moving works and adding -f keeps it from throwing error if the directory does not exist. 