### PR TITLE
Restricted mixlib-shellout gem version to 2.2.7 because higher versio…

### DIFF
--- a/oneops-admin/lib/shared/exec-gems-az.yaml
+++ b/oneops-admin/lib/shared/exec-gems-az.yaml
@@ -116,6 +116,9 @@ chef-12.11.18:
       - rest-client
       - 1.6.7
     -
+      - mixlib-shellout
+      - 2.2.7
+    -
       - ms_rest
       - 0.1.1
     -

--- a/oneops-admin/lib/shared/exec-gems.yaml
+++ b/oneops-admin/lib/shared/exec-gems.yaml
@@ -119,6 +119,9 @@ chef-12.11.18:
       - rest-client
       - 1.6.7
     -
+      - mixlib-shellout
+      - 2.2.7
+    -
       - ms_rest
       - 0.1.1
     -


### PR DESCRIPTION
…ns require Ruby >= 2.2

This issue surfaces when a gem repo has all versions of the gem. That's why we haven't caught this earlier, the gem repo we used only has version 2.2.7