### PR TITLE
modified gem path to discover gems installed using ruby from binary

### DIFF
--- a/inductor/src/main/resources/verification/kitchen-tmpl.yml
+++ b/inductor/src/main/resources/verification/kitchen-tmpl.yml
@@ -53,7 +53,7 @@ provisioner:
 verifier:
   name: busser
   ruby_bindir: /usr/bin
-  gem_path: /usr/local/share/gems:/tmp/verifier/gems
+  gem_path: /usr/lib/ruby/gems/2.0.0:/usr/local/share/gems:/tmp/verifier/gems
 platforms:
   - name: <platform_name>
 suites:


### PR DESCRIPTION
default gem installation path when ruby 2.0 is installed from binary is `/usr/lib/ruby/gems/2.0.0`. 
To discover the gems during kitchen ci tests this path has to be added in kitchen yaml file. 
