### PR TITLE
Modify Vagrantfile to support push of tomcat's war files into guest

### DIFF
--- a/oneops-packer/vagrant/Vagrantfile
+++ b/oneops-packer/vagrant/Vagrantfile
@@ -21,6 +21,11 @@ Vagrant.configure(2) do |config|
     vb.customize ["modifyvm", :id, "--cpuexecutioncap", "70"]
   end
 
+  # configure vagrant to push file from local to remote vm.
+  config.push.define "local-exec" do |push|
+    push.script = "update_war_file.sh"
+  end
+
   #if you want to sync circuits on your host with vagrant then create an env variable ONEOPS_HOME on your host that points to a directory that houses all the circuits and oneops core
   if !ENV['ONEOPS_HOME'].nil?
     config.vm.synced_folder ENV['ONEOPS_HOME']+"/circuit-oneops-1", "#{sync_folder_root}/circuit-oneops-1",owner: "root",group: "root"

--- a/oneops-packer/vagrant/update_war_file.sh
+++ b/oneops-packer/vagrant/update_war_file.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+[ -z "$OO_WAR_DIR" ] && echo "Missing OO_WAR_DIR" && exit 1;
+
+HOST=$(vagrant ssh-config|egrep 'HostName'|awk '{print $2}')
+USER=$(vagrant ssh-config|egrep 'User '|awk '{print $2}')
+PORT=$(vagrant ssh-config|egrep 'Port'|awk '{print $2}')
+IDENTITY=$(vagrant ssh-config|egrep 'IdentityFile'|awk '{print $2}')
+TEMP_DIR=/tmp/$(date +%s)
+DEST=/usr/local/tomcat/webapps
+
+ssh -qi $IDENTITY -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p $PORT $USER@$HOST mkdir -p $TEMP_DIR
+scp -qi $IDENTITY -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -P $PORT $OO_WAR_DIR/adapter.war $USER@$HOST:$TEMP_DIR/adapter.war
+scp -qi $IDENTITY -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -P $PORT $OO_WAR_DIR/antenna.war $USER@$HOST:$TEMP_DIR/antenna.war
+scp -qi $IDENTITY -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -P $PORT $OO_WAR_DIR/cms-admin.war $USER@$HOST:$TEMP_DIR/cms-admin.war
+scp -qi $IDENTITY -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -P $PORT $OO_WAR_DIR/controller.war $USER@$HOST:$TEMP_DIR/controller.war
+scp -qi $IDENTITY -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -P $PORT $OO_WAR_DIR/daq-api-1.0.0.war $USER@$HOST:$TEMP_DIR/daq-api-1.0.0.war
+scp -qi $IDENTITY -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -P $PORT $OO_WAR_DIR/opamp.war  $USER@$HOST:$TEMP_DIR/opamp.war
+scp -qi $IDENTITY -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -P $PORT $OO_WAR_DIR/sensor.war $USER@$HOST:$TEMP_DIR/sensor.war
+scp -qi $IDENTITY -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -P $PORT $OO_WAR_DIR/transistor.war $USER@$HOST:$TEMP_DIR/transistor.war
+scp -qi $IDENTITY -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -P $PORT $OO_WAR_DIR/transmitter.war $USER@$HOST:$TEMP_DIR/transmitter.war
+ssh -qi $IDENTITY -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p $PORT $USER@$HOST sudo cp $TEMP_DIR/*.* $DEST
+ssh -qi $IDENTITY -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p $PORT $USER@$HOST sudo systemctl restart tomcat.service
+ssh -qi $IDENTITY -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p $PORT $USER@$HOST rm -rf $TEMP_DIR
+


### PR DESCRIPTION
Modify Vagrantfile to support push of tomcat's war files into guest machine.

Must configure environment variable OO_WAR_DIR to path where vagrant
expect to find the folling files:  adapter.war, antenna.war, cms-admin.war,
controller.war, daq-api-1.0.0.war, opamp.war, sensor.war, transistor.war,
and transmitter.war.

Restart tomcat after files have been upload to guest machine.

Usage:

At the current directory where Vagrantfile is located you can run

# vagrant push

This will push all of those files above from specified directory into guest machine and restart tomcat to pick up new changes.