### PR TITLE
Limit max number of session that can be multiplex via same ssh sessions.

### DIFF
--- a/inductor/src/main/resources/verification/kitchen-tmpl.yml
+++ b/inductor/src/main/resources/verification/kitchen-tmpl.yml
@@ -50,6 +50,8 @@ provisioner:
     verify_api_cert: true
     ssl_verify_mode: :verify_peer
     log_level: :info
+transport:
+  max_ssh_sessions: 1
 verifier:
   name: busser
   ruby_bindir: /usr/bin


### PR DESCRIPTION
Limit max number of session that can be multiplex via same ssh session.

SSH server has default max limit of 10 which normally shouldn't be a problem,
but in the use case of net-scp it can reach limit very fast and thus resulting
in unexpected error this is misleading with vague SCP error.

In our use case where test-kitchen is running against multiple components against
few set of computes with same user e.g. oneops using ssh key.  This can cause
the connection to bump against the default limit really fast.  Ideal fix would
probably involve relaxing this limit to allow net-scp multiplex more connections
over the same session.

This temporary fix will slow down net-scp as it's now only allow to multiplex only
single connection per session to avoid running into the max limit.