### PR TITLE
Re-factored exec-order.rb

### DIFF
--- a/oneops-admin/lib/shared/exec-order.rb
+++ b/oneops-admin/lib/shared/exec-order.rb
@@ -7,6 +7,7 @@ require 'rubygems'
 require 'json'
 require 'yaml'
 require 'optparse'
+Dir[File.join(File.expand_path(File.dirname(__FILE__)), 'exec-order','*.rb')].each {|f| require f }
 
 log_level = "info"
 formatter = "null"
@@ -21,20 +22,13 @@ OptionParser.new do |opts|
   end
 end.parse!
 
-impl = ARGV[0]
-json_context = ARGV[1]
-cookbook_path = ARGV[2] || ''
+impl              = ARGV[0]
+json_context      = ARGV[1]
+cookbook_path     = ARGV[2] || ''
 service_cookbooks = ARGV[3] || ''
-
-puts "RUBY_PLATFORM: #{RUBY_PLATFORM}" if log_level == "debug"
-case RUBY_PLATFORM
-when /mingw/
-  ostype = 'windows'
-when /linux/
-  ostype = 'linux'
-end
-
-puts "os: #{ostype}" if log_level == "debug"
+primary_source    = ENV['rubygems_proxy'] || 'https://rubygems.org'
+secondary_source  = ENV['rubygemsbkp_proxy']
+ostype            = get_os_type(log_level)
 
 prefix_root = ''
 file_cache_path = '/tmp'
@@ -44,143 +38,28 @@ if ostype =~ /windows/
   impl = 'oo::chef-12.11.18'
   json_context = prefix_root + json_context
 end
-
-def gen_gemfile_and_install (gems, dsl, ostype, log_level)
-
-    rubygems_proxy = ENV['rubygems_proxy']
-
-    if rubygems_proxy.nil? && File.file?('/opt/oneops/rubygems_proxy')
-      rubygems_proxy = File.read('/opt/oneops/rubygems_proxy').chomp
-    end
-
-    gemfile_content = "source 'https://rubygems.org'\n"
-    if !rubygems_proxy.nil?
-      gemfile_content = "source '#{rubygems_proxy}'\n"
-    end
-    gems.each do |gem_set|
-      if gem_set.size > 1
-        gemfile_content += "gem '#{gem_set[0]}', '#{gem_set[1]}'\n"
-      else
-        gemfile_content += "gem '#{gem_set[0]}'\n"
-      end
-    end
-
-    current_dir = `pwd`.chomp
-    puts "pwd: #{current_dir}"
-
-    File.open('Gemfile', 'w') {|f| f.write(gemfile_content) }
-    method = "install"
-    result = ""
-    if ostype =~ /windows/
-      `c:\\opscode\\chef\\embedded\\bin\\gem list | grep #{dsl}`
-    else
-      `gem list | grep #{dsl}`
-    end
-    if $?.to_i == 0
-      method = "update"
-    end
-    cmd = ""
-    start_time = Time.now.to_i
-    if ostype =~ /windows/
-      cmd = "c:/opscode/chef/embedded/bin/bundle #{method}"
-    else
-      cmd = "bundle #{method} --full-index"
-    end
-    puts cmd  
-    ec = system cmd
-    
-    if !ec || ec.nil?
-      puts "bundle #{method} --full-index failed with, #{$?}"
-      exit 1
-    end
-    duration = Time.now.to_i - start_time
-    puts "took: #{duration} sec"
-
-    puts "change gem source back to rubygems_proxy"
-    rubygems_proxy = `cat /opt/oneops/rubygems_proxy`.chomp
-    puts "rubygems_proxy: #{rubygems_proxy}" if log_level == "debug"
-    if ostype =~ /windows/
-      system("c:/opscode/chef/embedded/bin/gem source --add #{rubygems_proxy}")
-      sources = `c:\\opscode\\chef\\embedded\\bin\\gem source | egrep -v "CURRENT SOURCES|#{rubygems_proxy}"`.split("\n")
-      sources.each do |source|
-        system("c:/opscode/chef/embedded/bin/gem source --remove #{source}")
-      end
-      system("c:/opscode/chef/embedded/bin/gem source")
-    else
-      `gem source --add #{rubygems_proxy}`
-      sources = `gem source | egrep -v "CURRENT SOURCES|#{rubygems_proxy}"`.split("\n")
-      sources.each do |source|
-        `gem source --remove #{source}`
-      end
-      `gem source`
-    end
-    
-    cmd_to_patch_azure_blob_sdk = "sed -i -e's/2012-02-12/2014-02-14/' \"$(dirname `gem which azure`)/azure/core/http/http_request.rb\""
-    system cmd_to_patch_azure_blob_sdk
-end
+dsl, version = impl.split('::')[1].split('-') # ex) oo::chef-10.16.6::optional_uri_for_cookbook_or_module
 
 # set cwd to same dir as the exe-order.rb file
 Dir.chdir File.dirname(__FILE__)
-gem_config = YAML::load(File.read('exec-gems.yaml'))
-
-# ex) oo::chef-10.16.6::optional_uri_for_cookbook_or_module
-dsl, version = impl.split("::")[1].split("-")
+gem_list = get_gem_list(dsl, version)
 
 case dsl
 when "chef"
   Dir.chdir "cookbooks"
 
-  if ostype =~ /windows/
-    if !File.exists?('c:/opscode/chef/embedded/bin/chef-client')
-      start_time = Time.now.to_i
-      ec = system("c:/programdata/chocolatey/choco.exe install -y --no-progress --allow-downgrade --allowEmptyChecksums chef-client -version 12.11.18")
-      if !ec || ec.nil?
-        puts "choco install result #{$?}"
-        exit 1
-      end
-      duration = Time.now.to_i - start_time
-      puts "installed chef-client in #{duration} seconds"
-
-      # patch the bug in chef 12.11.18
-      # https://github.com/chef/chef/issues/5027
-      # fixed here https://github.com/chef/chef/blame/master/lib/chef/chef_fs/file_system/multiplexed_dir.rb#L44
-      # but the chef-client msi was built and uploaded to chocolatey before it was fixed, so we need to temporarily add this
-      # until we can get a new version of the msi uploaded to chocolatey.
-      puts "Patch the bug in chef client!!!"
-      puts "run a substitute command and put the source back"
-      puts "SED command is: sed -i '44s/unless.*//' c:/opscode/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.11.18-universal-mingw32/lib/chef/chef_fs/file_system/multiplexed_dir.rb"
-      rc = system("sed -i '44s/unless.*//' c:/opscode/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.11.18-universal-mingw32/lib/chef/chef_fs/file_system/multiplexed_dir.rb")
-      if !rc || rc.nil?
-        puts "SED command failed with #{$?}"
-        exit 1
-      else
-        puts "SED Command Success!, #{$?}"
-      end
-
-      puts "DONE PATCHING THE CHEF BUG"
-    else
-      puts "Chef-client already installed, continuing with execution!!"
-    end
+  if ostype =~ /windows/ && !is_chef_installed?(ostype, version)
+    install_chef_windows(version)
+    patch_chef_121118 if version == '12.11.18'
   end
 
-  # check version
-  if ostype =~ /windows/
-    current_version = `c:\\opscode\\chef\\embedded\\bin\\bundle list | grep chef`.to_s.chomp
-  else
-    current_version = `bundle list | grep chef`.to_s.chomp
-  end
-  if $?.to_i != 0 || current_version.to_s.index(version).nil?
-    puts "current: #{current_version}, expected: #{version} - updating Gemfile"
-    version_gems = [["chef",version]]
-    puts "version_gems: #{version_gems}" 
-    if !gem_config["chef-#{version}"].nil?
-      puts "found chef-#{version} in gem config" if log_level == 'debug'
-      version_gems += gem_config["chef-#{version}"]
-    end
-    gem_list = gem_config["common"] + version_gems
-    gem_list.push(['chef', version])
-    gen_gemfile_and_install(gem_list, dsl, ostype, log_level)
-  end
+  #we want to make sure rubygems sources on the VM match rubygems_proxy env variable from compute cloud service
+  #otherwise changes to the cloud service will require updating compute component
+  #have to be called after chef is installed on windows, as that's the chef installation that also installs rubygems
+  update_gem_sources(primary_source, secondary_source, log_level)
+
+  #Run bunle to insert/update neccessary gems if needed
+  gen_gemfile_and_install(primary_source, gem_list, log_level)
 
 
   chef_config = "#{prefix_root}/home/oneops/#{cookbook_path}/components/cookbooks/chef-#{ci}.rb"
@@ -264,15 +143,12 @@ when "puppet"
   Dir.chdir "modules"
   modules_dir = `pwd`.chomp
 
-  # check version/install
-  current_version = `bundle exec puppet --version`.to_s.chomp
-  if $?.to_i != 0 || current_version != version
-    puts "current version: #{current_version} ... expecting #{version}"
-    puts "updating Gemfile and running bundle install."
-    gem_list = gem_config["common"] + gem_config["puppet"]
-    gem_list.push(['puppet', version])
-    gen_gemfile_and_install(gem_list,dsl,ostype,log_level)
-  end
+  #we want to make sure rubygems sources on the VM match rubygems_proxy env variable from compute cloud service
+  #otherwise changes to the cloud service will require updating compute component
+  update_gem_sources(primary_source, secondary_source, log_level)
+
+  #Run bunle to insert/update neccessary gems if needed
+  gen_gemfile_and_install(primary_source, gem_list, log_level)
 
   # run puppet apply for each item in the run_list
   context = JSON.parse(File.read(json_context))

--- a/oneops-admin/lib/shared/exec-order/chef.rb
+++ b/oneops-admin/lib/shared/exec-order/chef.rb
@@ -1,0 +1,38 @@
+def is_chef_installed? (ostype, version)
+  if ostype =~ /windows/ && !File.exists?("#{get_bin_dir}gem")
+    false
+  else
+    is_gem_installed?('chef', version)
+  end
+end
+
+def install_chef_windows(version)
+  start_time = Time.now.to_i
+  ec = system("c:/programdata/chocolatey/choco.exe install -y --no-progress --allow-downgrade --allowEmptyChecksums chef-client -version #{version}")
+  if !ec || ec.nil?
+    puts "choco install result #{$?}"
+    exit 1
+  end
+  duration = Time.now.to_i - start_time
+  puts "installed chef-client #{version} in #{duration} seconds"
+end
+
+def patch_chef_121118
+  # patch the bug in chef 12.11.18
+  # https://github.com/chef/chef/issues/5027
+  # fixed here https://github.com/chef/chef/blame/master/lib/chef/chef_fs/file_system/multiplexed_dir.rb#L44
+  # but the chef-client msi was built and uploaded to chocolatey before it was fixed, so we need to temporarily add this
+  # until we can get a new version of the msi uploaded to chocolatey.
+  puts "Patch the bug in chef client!!!"
+  puts "run a substitute command and put the source back"
+  puts "SED command is: sed -i '44s/unless.*//' c:/opscode/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.11.18-universal-mingw32/lib/chef/chef_fs/file_system/multiplexed_dir.rb"
+  rc = system("sed -i '44s/unless.*//' c:/opscode/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.11.18-universal-mingw32/lib/chef/chef_fs/file_system/multiplexed_dir.rb")
+  if !rc || rc.nil?
+    puts "SED command failed with #{$?}"
+    exit 1
+  else
+    puts "SED Command Success!, #{$?}"
+  end
+
+  puts "DONE PATCHING THE CHEF BUG"
+end

--- a/oneops-admin/lib/shared/exec-order/general.rb
+++ b/oneops-admin/lib/shared/exec-order/general.rb
@@ -1,0 +1,21 @@
+def get_os_type (log_level = 'info')
+  if RUBY_PLATFORM =~ /mingw/
+    ostype = 'windows'
+  else
+    ostype = 'linux'
+  end
+
+  if log_level == 'debug'
+    puts "RUBY_PLATFORM: #{RUBY_PLATFORM}"
+    puts "OS type: #{ostype}"
+  end
+  ostype
+end
+
+def get_bin_dir
+  get_os_type =~ /windows/ ? 'c:\\opscode\\chef\\embedded\\bin\\' : ''
+end
+
+def get_file_from_parent_dir(filename)
+  File.join(File.expand_path('..',File.dirname(__FILE__)),filename)
+end

--- a/oneops-admin/lib/shared/exec-order/rubygems.rb
+++ b/oneops-admin/lib/shared/exec-order/rubygems.rb
@@ -1,0 +1,119 @@
+def update_gem_sources (primary_source, secondary_source, log_level = 'info')
+  gem = "#{get_bin_dir}gem"
+  expected_sources = [primary_source, secondary_source]
+  puts "Expected gem sources: #{expected_sources}" if log_level == 'debug'
+  actual_sources = `#{gem} source`.split("\n").select{|l| (l =~ /^http/)}
+  puts "Actual gem sources: #{actual_sources}" if log_level == 'debug'
+  
+  if expected_sources != actual_sources
+    puts 'Expected gem sources do not match the actual gem sources. Updating...'
+    
+    #1.Remove all existing sources
+    actual_sources.each do |source|
+      `#{gem} source --remove #{source}`
+    end
+    #2.Add expected sources
+    expected_sources.each do |source|
+      `#{gem} source --add #{source}`
+    end
+  else
+    puts 'Expected gem sources match the actual gem sources.' if log_level == 'debug'
+  end
+
+  proxy_file = '/opt/oneops/rubygems_proxy'
+  if File.exists?(proxy_file) && File.read(proxy_file).chomp != primary_source
+    puts 'Rubygems_proxy config file is outdated. Updating...'
+    File.open(proxy_file, 'w') {|f| f.puts primary_source }
+  end
+end
+
+
+def get_gem_list (provisioner, version = nil)
+  require 'yaml'
+
+  config_file = get_file_from_parent_dir('exec-gems.yaml')
+  gem_config = YAML::load(File.read(config_file))
+
+  gem_list  = gem_config['common'] + [[provisioner,version]]
+  gem_list += gem_config[provisioner] if gem_config[provisioner]
+  gem_list += gem_config["#{provisioner}-#{version}"] if gem_config["#{provisioner}-#{version}"]
+
+  gem_list.uniq
+end
+
+
+def create_gemfile(rubygems_proxy, gems)
+  gemfile_content = "source '#{rubygems_proxy}'\n"
+
+  gems.each do |gem_set|
+    if gem_set.size > 1
+      gemfile_content += "gem '#{gem_set[0]}', '#{gem_set[1]}'\n"
+    else
+      gemfile_content += "gem '#{gem_set[0]}'\n"
+    end
+  end
+
+  File.open('Gemfile', 'w') {|f| f.write(gemfile_content) }
+end
+
+
+def is_gem_installed?(gem, version)
+  out = `#{get_bin_dir}gem list ^#{gem}$ -i -v #{version}`.chomp
+  if out == 'true'
+    true
+  else
+    false
+  end
+end
+
+
+def check_gem_update_needed (gems, log_level = 'info')
+  update_needed = false
+
+  gems.each do |g|
+    if !is_gem_installed?(g[0],g[1])
+      puts "Gem #{g[0]} version #{g[1]} is not installed." if log_level == 'debug'
+      update_needed = true
+      break
+    end 
+  end
+
+  update_needed
+end
+
+
+def gen_gemfile_and_install (rubygems_proxy, gems, log_level)
+
+    #Determine bundle method 
+    #  - install if running for the first time
+    #  - update if any gems from exec-gems.yaml have mismatching versions
+
+    if !File.exists?('Gemfile.lock')
+      puts 'Gemfile.lock is not found, will run bundle install.' if log_level == 'debug'
+      method = 'install'
+      create_gemfile(rubygems_proxy, gems)
+    elsif check_gem_update_needed(gems, log_level)
+      puts 'Gemfile.lock is found, and gem update is required.' if log_level == 'debug'
+      File.delete('Gemfile') #re-create Gemfile in case the exec-gems.yaml has changed
+      create_gemfile(rubygems_proxy, gems)
+      method = 'update'
+    else
+      puts 'Gemfile.lock is found, and no gem update is required.' if log_level == 'debug'
+      method = nil
+    end
+
+    if !method.nil?
+      start_time = Time.now.to_i
+      cmd = "#{get_bin_dir}bundle #{method} --full-index"
+      ec = system cmd
+
+      if !ec || ec.nil?
+        puts "#{cmd} failed with, #{$?}"
+        exit 1
+      end
+      puts "#{cmd} took: #{Time.now.to_i - start_time} sec"
+
+      cmd_to_patch_azure_blob_sdk = "sed -i -e's/2012-02-12/2014-02-14/' \"$(dirname `gem which azure`)/azure/core/http/http_request.rb\""
+      system cmd_to_patch_azure_blob_sdk
+    end
+end


### PR DESCRIPTION
All changes can be split into 3 categories:
1) a little bit of re-factoring and code cleaning, put some of the logic into
library files, under its own directory - exec-gems
2) On every execution check that rubygems_proxy ENV variable matches rubygems
source on the VM. Fix if not.
3) On every execution check that all the gems listed in exec-gems.yaml are
actually installed on the VM. If not, re-create Gemfile and run bundle update.

Change #2 solves the issue where updating cloud service with the new rubygems
proxy requires touching compute component, to get the change applied to the VM.

Change #3 solves the issue where we may add or bump up a gem version in
exec-gems.yaml file, and have code that relies on the new gem/version,
but the VM wouldn't have it installed.