### PR TITLE
script to cache gems listed in exec-gems & exec-gems-az yaml files

### DIFF
--- a/oneops-admin/lib/shared/cache-exec-gems.rb
+++ b/oneops-admin/lib/shared/cache-exec-gems.rb
@@ -1,0 +1,41 @@
+#!/usr/bin/env ruby
+require 'optparse'
+require 'yaml'
+Dir[File.join(File.expand_path(File.dirname(__FILE__)), 'exec-order','*.rb')].each {|f| require f }
+
+# set cwd to same dir as the cache-exec-gems.rb file
+Dir.chdir File.dirname(__FILE__)
+
+log_level = "debug"
+gem_sources  = get_gem_sources
+config_files = [get_file_from_parent_dir('exec-gems.yaml'), get_file_from_parent_dir('exec-gems-az.yaml')]
+
+config_files.each do |config_file|
+
+  puts "parsing config_file #{config_file}"
+
+  gem_config = YAML::load(File.read(config_file))
+  gem_config.keys.each do |impl|
+    dsl, version = impl.split('-')
+    puts "dsl=#{dsl}, version=#{version}"
+    case dsl
+      when "chef"
+        if (version != "12.11.18")
+          gem_list = get_gem_list(dsl, version, config_file.split('/').last)
+          gen_gemfile_and_install(gem_sources, gem_list, log_level, 'package')
+
+          if File.exists?('Gemfile')
+            File.delete('Gemfile')
+          end
+          if File.exists?('Gemfile.lock')
+            File.delete('Gemfile.lock')
+          end
+        else
+          puts "skipping packaging gems for chef 12.11.18"
+        end
+    end
+  end
+end
+
+
+

--- a/oneops-admin/lib/shared/exec-order/rubygems.rb
+++ b/oneops-admin/lib/shared/exec-order/rubygems.rb
@@ -56,10 +56,13 @@ def update_gem_sources (expected_sources, log_level = 'info')
 end
 
 
-def get_gem_list (provisioner, version = nil)
+def get_gem_list (provisioner, version = nil, config_file_name = nil)
   require 'yaml'
 
-  config_file = get_file_from_parent_dir('exec-gems.yaml')
+  if config_file_name.nil?
+    config_file_name = 'exec-gems.yaml'
+  end
+  config_file = get_file_from_parent_dir(config_file_name)
   gem_config = YAML::load(File.read(config_file))
 
   gem_list  = gem_config['common'] + [[provisioner,version]]
@@ -110,29 +113,52 @@ def check_gem_update_needed (gems, log_level = 'info')
 end
 
 
-def gen_gemfile_and_install (gem_sources, gems, log_level)
+def gen_gemfile_and_install (gem_sources, gems, log_level, bundle_method = nil)
 
-    #2 scenarions when need to run bundle install
-    #  - if running for the first time
-    #  - if any gems from exec-gems.yaml have mismatching versions
+    if bundle_method.nil?
+      #2 scenarions when need to run bundle install
+      #  - if running for the first time
+      #  - if any gems from exec-gems.yaml have mismatching versions
 
-    if !File.exists?('Gemfile.lock')
-      puts 'Gemfile.lock is not found, will run bundle install.' if log_level == 'debug'
-      method = 'install'
-      create_gemfile(gem_sources, gems)
-    elsif check_gem_update_needed(gems, log_level)
-      puts 'Gemfile.lock is found, and gem update is required.' if log_level == 'debug'
-      ['Gemfile', 'Gemfile.lock'].each {|f| File.delete(f) if File.file?(f)}
-      create_gemfile(gem_sources, gems)
-      method = 'install'
+      if !File.exists?('Gemfile.lock')
+        puts 'Gemfile.lock is not found, will run bundle install.' if log_level == 'debug'
+        method = 'install'
+        create_gemfile(gem_sources, gems)
+      elsif check_gem_update_needed(gems, log_level)
+        puts 'Gemfile.lock is found, and gem update is required.' if log_level == 'debug'
+        ['Gemfile', 'Gemfile.lock'].each {|f| File.delete(f) if File.file?(f)}
+        create_gemfile(gem_sources, gems)
+        method = 'install'
+      else
+        puts 'Gemfile.lock is found, and no gem update is required.' if log_level == 'debug'
+        method = nil
+      end
     else
-      puts 'Gemfile.lock is found, and no gem update is required.' if log_level == 'debug'
-      method = nil
+      #if bundle method is provided
+      if bundle_method == 'package'
+        puts "bundle method is #{bundle_method}" if log_level == 'debug'
+        method = 'package'
+        create_gemfile(gem_sources, gems)
+
+        if(log_level == 'debug')
+          puts 'Gemfile content is:'
+          File.open('Gemfile').each do |line|
+            puts line
+          end
+        end
+      else
+        method = nil
+      end
     end
 
     if !method.nil?
       start_time = Time.now.to_i
-      cmd = "#{get_bin_dir}bundle #{method} --full-index"
+      cmd = case method
+              when 'install'
+                "#{get_bin_dir}bundle #{method} --full-index"
+              when 'package'
+                "#{get_bin_dir}bundle #{method} --no-install --no-prune"
+            end
       ec = system cmd
 
       if !ec || ec.nil?

--- a/oneops-admin/lib/shared/exec-order/rubygems.rb
+++ b/oneops-admin/lib/shared/exec-order/rubygems.rb
@@ -56,10 +56,13 @@ def update_gem_sources (expected_sources, log_level = 'info')
 end
 
 
-def get_gem_list (provisioner, version = nil)
+def get_gem_list (provisioner, version = nil, config_file_name = nil)
   require 'yaml'
 
-  config_file = get_file_from_parent_dir('exec-gems.yaml')
+  if config_file_name.nil?
+    config_file_name = 'exec-gems.yaml'
+  end
+  config_file = get_file_from_parent_dir(config_file_name)
   gem_config = YAML::load(File.read(config_file))
 
   gem_list  = gem_config['common'] + [[provisioner,version]]
@@ -110,29 +113,53 @@ def check_gem_update_needed (gems, log_level = 'info')
 end
 
 
-def gen_gemfile_and_install (gem_sources, gems, log_level)
+def gen_gemfile_and_install (gem_sources, gems, log_level, bundle_method = nil)
 
-    #Determine bundle method
-    #  - install if running for the first time
-    #  - update if any gems from exec-gems.yaml have mismatching versions
-
-    if !File.exists?('Gemfile.lock')
-      puts 'Gemfile.lock is not found, will run bundle install.' if log_level == 'debug'
-      method = 'install'
-      create_gemfile(gem_sources, gems)
-    elsif check_gem_update_needed(gems, log_level)
-      puts 'Gemfile.lock is found, and gem update is required.' if log_level == 'debug'
-      File.delete('Gemfile') #re-create Gemfile in case the exec-gems.yaml has changed
-      create_gemfile(gem_sources, gems)
-      method = 'update'
+    if bundle_method.nil?
+      #Determine bundle method
+      #  - install if running for the first time
+      #  - update if any gems from exec-gems.yaml have mismatching versions
+      if !File.exists?('Gemfile.lock')
+        puts 'Gemfile.lock is not found, will run bundle install.' if log_level == 'debug'
+        method = 'install'
+        create_gemfile(gem_sources, gems)
+      elsif check_gem_update_needed(gems, log_level)
+        puts 'Gemfile.lock is found, and gem update is required.' if log_level == 'debug'
+        File.delete('Gemfile') #re-create Gemfile in case the exec-gems.yaml has changed
+        create_gemfile(gem_sources, gems)
+        method = 'update'
+      else
+        puts 'Gemfile.lock is found, and no gem update is required.' if log_level == 'debug'
+        method = nil
+      end
     else
-      puts 'Gemfile.lock is found, and no gem update is required.' if log_level == 'debug'
-      method = nil
+      #if bundle method is provided
+      if bundle_method == 'package'
+        puts "bundle method is #{bundle_method}" if log_level == 'debug'
+        method = 'package'
+        create_gemfile(gem_sources, gems)
+
+        if(log_level == 'debug')
+          puts 'Gemfile content is:'
+          File.open('Gemfile').each do |line|
+            puts line
+          end
+        end
+      else
+        method = nil
+      end
     end
 
     if !method.nil?
       start_time = Time.now.to_i
-      cmd = "#{get_bin_dir}bundle #{method} --full-index"
+
+      cmd = case method
+              when 'install','update'
+                "#{get_bin_dir}bundle #{method} --full-index"
+              when 'package'
+                "#{get_bin_dir}bundle #{method} --no-install --no-prune"
+            end
+
       ec = system cmd
 
       if !ec || ec.nil?
@@ -142,4 +169,5 @@ def gen_gemfile_and_install (gem_sources, gems, log_level)
       puts "#{cmd} took: #{Time.now.to_i - start_time} sec"
 
     end
+
 end


### PR DESCRIPTION
the idea is to install gems from local repo when exec-order.rb is executed. normally, exec-order.rb creates a dynamic Gemfile based on the contents from exec-gems or exec-gems-az yaml file and `bundle install` it on the compute. with this change, and when this script is run during build, all the gems from those yaml files will be cached in `vendor/cache` folder. 
next time when exec-order is called this cache folder is rsync to compute. once this local repo is now on compute these can be installed using `bundle install --local`