### PR TITLE
Work around for the older ruby in azure VMs

### DIFF
--- a/oneops-admin/lib/shared/exec-order.rb
+++ b/oneops-admin/lib/shared/exec-order.rb
@@ -38,6 +38,11 @@ if ostype =~ /windows/
   json_context = prefix_root + json_context
 end
 dsl, version = impl.split('::')[1].split('-') # ex) oo::chef-10.16.6::optional_uri_for_cookbook_or_module
+if !ENV['class'].nil? && !ENV['class'].empty?
+  component = ENV['class'].downcase
+else
+  component = json_context.split('/').last.split('.').first.downcase
+end
 
 # set cwd to same dir as the exe-order.rb file
 Dir.chdir File.dirname(__FILE__)
@@ -58,7 +63,7 @@ when "chef"
   update_gem_sources(gem_sources, log_level)
 
   #Run bunle to insert/update neccessary gems if needed
-  gen_gemfile_and_install(gem_sources, gem_list, log_level)
+  gen_gemfile_and_install(gem_sources, gem_list, component, log_level)
 
 
   chef_config = "#{prefix_root}/home/oneops/#{cookbook_path}/components/cookbooks/chef-#{ci}.rb"
@@ -147,7 +152,7 @@ when "puppet"
   update_gem_sources(gem_sources, log_level)
 
   #Run bunle to insert/update neccessary gems if needed
-  gen_gemfile_and_install(gem_sources, gem_list, log_level)
+  gen_gemfile_and_install(gem_sources, gem_list, component, log_level)
 
   # run puppet apply for each item in the run_list
   context = JSON.parse(File.read(json_context))

--- a/oneops-admin/lib/shared/exec-order/rubygems.rb
+++ b/oneops-admin/lib/shared/exec-order/rubygems.rb
@@ -110,24 +110,28 @@ def check_gem_update_needed (gems, log_level = 'info')
 end
 
 
-def gen_gemfile_and_install (gem_sources, gems, log_level)
+def gen_gemfile_and_install (gem_sources, gems, component, log_level)
 
     #2 scenarions when need to run bundle install
     #  - if running for the first time
     #  - if any gems from exec-gems.yaml have mismatching versions
 
+    method = nil
     if !File.exists?('Gemfile.lock')
       puts 'Gemfile.lock is not found, will run bundle install.'
       method = 'install'
       create_gemfile(gem_sources, gems)
     elsif check_gem_update_needed(gems, log_level)
-      puts 'Gemfile.lock is found, and gem update is required.'
-      ['Gemfile', 'Gemfile.lock'].each {|f| File.delete(f) if File.file?(f)}
-      create_gemfile(gem_sources, gems)
-      method = 'install'
+      if ['objectstore','compute','volume', 'os'].include?(component)
+        puts "Gemfile.lock is found, and gem update is required for component: #{component}"
+        ['Gemfile', 'Gemfile.lock'].each {|f| File.delete(f) if File.file?(f)}
+        create_gemfile(gem_sources, gems)
+        method = 'install'
+      else
+        puts "Gem update is required but will not be run for component: #{component}"
+      end
     else
       puts 'Gemfile.lock is found, and no gem update is required.'
-      method = nil
     end
 
     if !method.nil?


### PR DESCRIPTION
The issue presents itself when a component update is run and gem sync is found to be needed,
which for instance happens for Azure VMs, which now require fog-azure-rm gem.
The the problem with the older CentOS is that their version of ruby is not compatible with
the fog-azure-rm gem.
This fix restricts the scope of the issue to the volume and objectstore component, the ones
that actually need the fog-azure-rm.
For other components the gem sync will not run.