### PR TITLE
Changed how we decide to run initial bundle install

### DIFF
--- a/oneops-admin/lib/shared/exec-order.rb
+++ b/oneops-admin/lib/shared/exec-order.rb
@@ -63,7 +63,7 @@ when "chef"
   update_gem_sources(gem_sources, log_level)
 
   #Run bunle to insert/update neccessary gems if needed
-  gen_gemfile_and_install(gem_sources, gem_list, component, log_level)
+  gen_gemfile_and_install(gem_sources, gem_list, component, dsl, log_level)
 
 
   chef_config = "#{prefix_root}/home/oneops/#{cookbook_path}/components/cookbooks/chef-#{ci}.rb"
@@ -152,7 +152,7 @@ when "puppet"
   update_gem_sources(gem_sources, log_level)
 
   #Run bunle to insert/update neccessary gems if needed
-  gen_gemfile_and_install(gem_sources, gem_list, component, log_level)
+  gen_gemfile_and_install(gem_sources, gem_list, component, dsl, log_level)
 
   # run puppet apply for each item in the run_list
   context = JSON.parse(File.read(json_context))


### PR DESCRIPTION
Before we would check for existance of Gemfile.lock, but that could lead to
issues when a previous deployment breaks during bundle install, because it
would result in deleting Gemfile.lock without creating a new one. So the next
run of exec-order.rb will see missing Gemfile.lock and will try to do bundle
install even if it's not actually required.
Now we will be checking for existance of the provisioner gem itself (chef,
puppet), and if the gem is not found we will run bundle install regardless