### PR TITLE
Run chef-solo through bundle exec to ensure clean environment of rubygems.

### DIFF
--- a/oneops-admin/lib/shared/exec-order.rb
+++ b/oneops-admin/lib/shared/exec-order.rb
@@ -134,7 +134,7 @@ when "chef"
   if version.split('.')[0].to_i >= 12
     cmd = "#{bindir}/chef-client --local-mode -c #{chef_config} -j #{json_context}"
   else
-    cmd = "#{bindir}/chef-solo -l #{log_level} -F #{formatter} -c #{chef_config} -j #{json_context}"
+    cmd = "bundle exec #{bindir}/chef-solo -l #{log_level} -F #{formatter} -c #{chef_config} -j #{json_context}"
   end
   puts cmd
   system cmd


### PR DESCRIPTION
Since all Ruby gems are configure and install through Bundler it 
is best to run any app without using binstubs is through the
the usage of bundle exec.  This ensure that the right gems
are loaded as specified in Gemfile irregardless of any other
versions installed on the system.