### PR TITLE
Pin i18n and activesupport so they can be installed with Ruby 1.8.7

### DIFF
--- a/oneops-admin/lib/shared/exec-gems-az.yaml
+++ b/oneops-admin/lib/shared/exec-gems-az.yaml
@@ -32,7 +32,13 @@ common:
     -
       - parallel
       - 1.3.3
-
+    # gem dependencies for artifact component
+    -
+      - i18n
+      - 0.6.9
+    -
+      - activesupport
+      - 3.2.11
 chef-10.16.6:
     # workaround for chef install dependency issues
     # http://stackoverflow.com/questions/14738091/cant-install-chef-gem-version-conflict-with-net-ssh-net-ssh-multi-net-ssh-gate

--- a/oneops-admin/lib/shared/exec-gems.yaml
+++ b/oneops-admin/lib/shared/exec-gems.yaml
@@ -38,7 +38,13 @@ common:
     -
       - parallel
       - 1.3.3
-
+    # gem dependencies for artifact component
+    -
+      - i18n
+      - 0.6.9
+    -
+      - activesupport
+      - 3.2.11
 chef-10.16.6:
     # workaround for chef install dependency issues
     # http://stackoverflow.com/questions/14738091/cant-install-chef-gem-version-conflict-with-net-ssh-net-ssh-multi-net-ssh-gate


### PR DESCRIPTION
Pin i18n and activesupport so they can be installed without
pulling the latest which is not compatible with Ruby 1.8.7.