### PR TITLE
restricting ffi to 1.9.18 because 1.9.21 requires libffi-devel packag…

### DIFF
--- a/oneops-admin/lib/shared/exec-gems-az.yaml
+++ b/oneops-admin/lib/shared/exec-gems-az.yaml
@@ -32,6 +32,9 @@ common:
     -
       - parallel
       - 1.3.3
+    -
+      - ffi
+      - 1.9.18
     # gem dependencies for artifact component
     -
       - i18n

--- a/oneops-admin/lib/shared/exec-gems.yaml
+++ b/oneops-admin/lib/shared/exec-gems.yaml
@@ -38,6 +38,9 @@ common:
     -
       - parallel
       - 1.3.3
+    -
+      - ffi
+      - 1.9.18
     # gem dependencies for artifact component
     -
       - i18n


### PR DESCRIPTION
…e which is currently not installed on computes