### PR TITLE
Updating exising Ruby to 2.0.0-p648.

### DIFF
--- a/oneops-admin/lib/shared/exec-order.rb
+++ b/oneops-admin/lib/shared/exec-order.rb
@@ -53,6 +53,13 @@ end
 # deletect if we are spawn from previous update
 # for provisioner to be 11.12.18 instead of
 # older version of chef.
+
+if Gem::Version.new(RUBY_VERSION.dup) == Gem::Version.new("2.0.0") 
+  if version.eql?("11.4.0")
+    version = "11.18.12" # update older version to newer version
+  end
+end
+
 result = update_ruby(component,json_context)
 
 if result["updated"] == true # must use this syntax as older version of ruby doesn't use hash[:key]

--- a/oneops-admin/lib/shared/exec-order.rb
+++ b/oneops-admin/lib/shared/exec-order.rb
@@ -53,7 +53,7 @@ end
 # deletect if we are spawn from previous update
 # for provisioner to be 11.12.18 instead of
 # older version of chef.
-result = update_ruby(component)
+result = update_ruby(component,json_context)
 
 if result["updated"] == true # must use this syntax as older version of ruby doesn't use hash[:key]
   system "#{result["ruby_bin"]} shared/exec-order.rb #{result["impl"]} #{json_context} #{cookbook_path} #{service_cookbooks}"

--- a/oneops-admin/lib/shared/exec-order.rb
+++ b/oneops-admin/lib/shared/exec-order.rb
@@ -50,10 +50,13 @@ else
   component = json_context.split('/').last.split('.').first.downcase
 end
 
+# deletect if we are spawn from previous update
+# for provisioner to be 11.12.18 instead of
+# older version of chef.
 result = update_ruby(component)
 
-if result[:updated] 
-  system "#{result[:ruby_bin]} shared/exec-order.rb #{impl} #{json_context} #{cookbook_path} #{service_cookbooks}"
+if result["updated"] == true # must use this syntax as older version of ruby doesn't use hash[:key]
+  system "#{result["ruby_bin"]} shared/exec-order.rb #{result["impl"]} #{json_context} #{cookbook_path} #{service_cookbooks}"
   if $?.exitstatus != 0
     puts "CHEF SOLO failed, #{$?}"
   end

--- a/oneops-admin/lib/shared/exec-order/general.rb
+++ b/oneops-admin/lib/shared/exec-order/general.rb
@@ -13,7 +13,10 @@ def get_os_type (log_level = 'info')
 end
 
 def get_bin_dir
-  get_os_type =~ /windows/ ? 'c:\\opscode\\chef\\embedded\\bin\\' : ''
+  os_type = get_os_type
+  bin_dir = (os_type =~ /windows/ ? 'c:\\opscode\\chef\\embedded\\bin\\' : '')
+  bin_dir = File.file?("/home/oneops/ruby/ruby-2.0.0-p648/bin/ruby") ? "/home/oneops/ruby/ruby-2.0.0-p648/bin/" : bin_dir
+  bin_dir = File.file?("/home/oneops/ruby/2.0.0-p648/bin/ruby") ? "/home/oneops/ruby/2.0.0-p648/bin/" : bin_dir
 end
 
 def get_file_from_parent_dir(filename)
@@ -22,4 +25,72 @@ end
 
 def get_proxy_file_name
   (get_os_type =~ /windows/ ? 'c:/cygwin64' : '') + '/opt/oneops/rubygems_proxy'
+end
+
+def update_ruby(component)
+  #
+  # Check to see if we have older Ruby version
+  # We are not modifying anything. Let's the Ruby
+  # system kicks off this, if we detects older
+  # version when can kick off the update process
+  # only if it's hasn't been done.  If the update
+  # has been performed then it will use the newer
+  # Ruby instead of system Ruby.
+  #
+
+  if (Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new("2.0.0")) && (['objectstore','compute','volume', 'os'].include?(component))
+    install_ruby_cmd = "curl #{ENV['RUBY2_BINARY_proxy']} | tar Pxz  && /home/oneops/ruby/ruby-2.0.0-p648/bin/gem install bundler --no-ri --no-rdoc  && chown -R oneops:oneops /home/oneops/ruby"
+    ruby_binary_path = "/home/oneops/ruby/ruby-2.0.0-p648/bin/ruby"
+    ruby_bin = File.file?(ruby_binary_path) ? ruby_binary_path : "/usr/bin/ruby"
+
+    updated = ruby_bin.eql?(ruby_binary_path) ? true : false
+
+    if updated && File.exists?('/home/oneops/ruby/ruby-2.0.0-p648/lib/ruby/gems/2.0.0')
+      ENV['GEM_PATH'] = '/home/oneops/ruby/ruby-2.0.0-p648/lib/ruby/gems/2.0.0'
+      ENV['PATH'] = "/home/oneops/ruby/ruby-2.0.0-p648/bin:#{ENV['PATH']}"
+    end
+
+    impl = "oo::chef-11.18.12"
+
+    unless File.file?(ruby_binary_path)
+      # If RUBY2_BINARY_proxy is not available as ENV
+      # then skip otherwise continue
+      # This RUBY2_BINARY environment must be configured
+      # in the cloud setup of the compute that point
+      # to a stand alone pre-compiled Ruby 2.0.0
+      unless ENV['RUBY2_BINARY_proxy'].to_s.empty?
+        File.open("/tmp/ruby2.lock", File::RDWR|File::CREAT, 0644) { |f|
+          # Put in exclusive write lock 
+          # if we can't get a write lock then
+          # we must not proceed with the update
+          # this ensure that only one process
+          # can run this update at any given time
+          # 
+          # If we can't get the exclusive lock it would
+          # return false
+          # This is a non-block call with File::LOCK_NB
+          if f.flock(File::LOCK_EX|File::LOCK_NB)
+            puts "Downloading and installing Ruby 2.0.0 ..."
+            puts "Running command #{install_ruby_cmd}"
+            system install_ruby_cmd
+            if $?.exitstatus != 0
+              puts "Failed to update Ruby to newer version"
+            else
+              if File.file?(ruby_binary_path)
+                updated = true
+                ruby_bin = ruby_binary_path
+
+                if File.exists?('/home/oneops/ruby/ruby-2.0.0-p648/lib/ruby/gems/2.0.0')
+                  ENV['GEM_PATH'] = '/home/oneops/ruby/ruby-2.0.0-p648/lib/ruby/gems/2.0.0'
+                  ENV['PATH'] = "/home/oneops/ruby/ruby-2.0.0-p648/bin:#{ENV['PATH']}"
+                end
+              end
+            end
+            f.flock(File::LOCK_UN)
+          end
+        }
+      end
+    end
+  end
+  return { "updated" => updated, "ruby_bin" => ruby_bin, "impl" => impl }
 end

--- a/oneops-admin/lib/shared/exec-order/general.rb
+++ b/oneops-admin/lib/shared/exec-order/general.rb
@@ -39,15 +39,15 @@ def update_ruby(component)
   #
 
   if (Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new("2.0.0")) && (['objectstore','compute','volume', 'os'].include?(component))
-    install_ruby_cmd = "curl #{ENV['RUBY2_BINARY_proxy']} | tar Pxz  && /home/oneops/ruby/ruby-2.0.0-p648/bin/gem install bundler --no-ri --no-rdoc  && chown -R oneops:oneops /home/oneops/ruby"
-    ruby_binary_path = "/home/oneops/ruby/ruby-2.0.0-p648/bin/ruby"
+    install_ruby_cmd = "curl #{ENV['RUBY2_BINARY_proxy']} | tar Pxz  && /home/oneops/ruby/2.0.0-p648/bin/gem install bundler --no-ri --no-rdoc  && chown -R oneops:oneops /home/oneops/ruby"
+    ruby_binary_path = "/home/oneops/ruby/2.0.0-p648/bin/ruby"
     ruby_bin = File.file?(ruby_binary_path) ? ruby_binary_path : "/usr/bin/ruby"
 
     updated = ruby_bin.eql?(ruby_binary_path) ? true : false
 
-    if updated && File.exists?('/home/oneops/ruby/ruby-2.0.0-p648/lib/ruby/gems/2.0.0')
-      ENV['GEM_PATH'] = '/home/oneops/ruby/ruby-2.0.0-p648/lib/ruby/gems/2.0.0'
-      ENV['PATH'] = "/home/oneops/ruby/ruby-2.0.0-p648/bin:#{ENV['PATH']}"
+    if updated && File.exists?('/home/oneops/ruby/2.0.0-p648/lib/ruby/gems/2.0.0')
+      ENV['GEM_PATH'] = '/home/oneops/ruby/2.0.0-p648/lib/ruby/gems/2.0.0'
+      ENV['PATH'] = "/home/oneops/ruby/2.0.0-p648/bin:#{ENV['PATH']}"
     end
 
     impl = "oo::chef-11.18.12"
@@ -80,9 +80,9 @@ def update_ruby(component)
                 updated = true
                 ruby_bin = ruby_binary_path
 
-                if File.exists?('/home/oneops/ruby/ruby-2.0.0-p648/lib/ruby/gems/2.0.0')
-                  ENV['GEM_PATH'] = '/home/oneops/ruby/ruby-2.0.0-p648/lib/ruby/gems/2.0.0'
-                  ENV['PATH'] = "/home/oneops/ruby/ruby-2.0.0-p648/bin:#{ENV['PATH']}"
+                if File.exists?('/home/oneops/ruby/2.0.0-p648/lib/ruby/gems/2.0.0')
+                  ENV['GEM_PATH'] = '/home/oneops/ruby/2.0.0-p648/lib/ruby/gems/2.0.0'
+                  ENV['PATH'] = "/home/oneops/ruby/2.0.0-p648/bin:#{ENV['PATH']}"
                 end
               end
             end


### PR DESCRIPTION
This PR will prepare exec-order.rb to perform update to existing
system where we have older version of Ruby (e.g. 1.8.7).  This
will also will be compatible with upcoming Fast Image effort where
Ruby 2.0.0 is pre-installed.

This update procedure will not activate unless the cloud config
for the compute has been configured with env RUBY2_BINARY.  This
env must be a valid Ruby 2.0.0-p648 binary (pre-compiled).  This
also mean that it must be installed at the following location:
/home/oneops/ruby/ruby-2.0.0-p648.

On the first run when it is successfully acquired WRITE lock
only then Ruby update will happen.  This to ensure that we are
perform Ruby update with multiple proccesses.  Once the system
has been update exec-order.rb will be configured to use the new
Ruby.  At that point it will be just a wrapper to relaunch itself
by using newer Ruby.

Expectation on the inital run can run anywhere between 1-3 minutes
while Ruby 2.0 is being download and install.  Any subsequent runs
it will be normal.