### PR TITLE
ffi gem installation issue fixed.

### DIFF
--- a/oneops-admin/oneops-admin-adapter.gemspec
+++ b/oneops-admin/oneops-admin-adapter.gemspec
@@ -47,5 +47,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'nokogiri', '= 1.5.11'
   s.add_dependency 'fog-openstack', '= 0.1.21'
   s.add_dependency 'mixlib-config', '= 2.2.4'
-  s.add_dependency 'ffi', '= 1.9.10'
+  s.add_dependency 'ffi', '= 1.9.18'
 end

--- a/oneops-admin/oneops-admin-adapter.gemspec
+++ b/oneops-admin/oneops-admin-adapter.gemspec
@@ -47,4 +47,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'nokogiri', '= 1.5.11'
   s.add_dependency 'fog-openstack', '= 0.1.21'
   s.add_dependency 'mixlib-config', '= 2.2.4'
+  s.add_dependency 'ffi', '= 1.9.10'
 end

--- a/oneops-admin/oneops-admin-inductor-az.gemspec
+++ b/oneops-admin/oneops-admin-inductor-az.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'json', '= 1.8.6'
   s.add_dependency 'fog', '= 1.38.0'
   s.add_dependency 'fog-openstack', '= 0.1.21'
-  s.add_dependency 'ffi', '= 1.9.10'
+  s.add_dependency 'ffi', '= 1.9.18'
   s.add_dependency 'nokogiri', '~> 1.6.0'
   s.add_dependency 'ohai', '= 7.4.1'
   s.add_dependency 'mixlib-shellout', '= 1.4.0'

--- a/oneops-admin/oneops-admin-inductor.gemspec
+++ b/oneops-admin/oneops-admin-inductor.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'fog', '= 1.38.0'
   s.add_dependency 'fog-aliyun', '= 0.1.0'
-  s.add_dependency 'ffi', '= 1.9.10'
+  s.add_dependency 'ffi', '= 1.9.18'
   s.add_dependency 'nokogiri', '= 1.5.11'
   s.add_dependency 'ohai', '= 7.4.1'
   s.add_dependency 'mixlib-shellout', '= 1.4.0'

--- a/oneops-admin/oneops-admin.gemspec
+++ b/oneops-admin/oneops-admin.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency "activesupport", '= 4.1.10'
   s.add_dependency "activeresource", '= 4.0.0'
   s.add_dependency "activemodel", '= 4.1.10'
-  s.add_dependency "ffi", '= 1.9.10'
+  s.add_dependency "ffi", '= 1.9.18'
   s.add_dependency "fog", '= 1.38.0'
   s.add_dependency "aws-s3", '= 0.6.3'
   s.add_dependency "chef", '= 11.18.12'


### PR DESCRIPTION
ffi gem issue arose few weeks ago. This issue was due to that the newer version requires libffi-devel package. We restricted its version to 1.9.18 which doesn't need any extra libraries.

- Added dependency in oneops-admin-adapter.gemspec
- Bumped version in oneops-admin-inductor-az.gemspec
- Bumped version in oneops-admin-inductor.gemspec
- Bumped version in oneops-admin.gemspec