### PR TITLE
 tests to make sure getOpenRfcByCidIdList call is supported by InMemoryDJMapper

### DIFF
--- a/transistor/src/main/java/com/oneops/transistor/service/ManifestManagerImpl.java
+++ b/transistor/src/main/java/com/oneops/transistor/service/ManifestManagerImpl.java
@@ -681,12 +681,15 @@ public class ManifestManagerImpl implements ManifestManager {
 				ManifestRfcContainer manifestPlatformRfcs =  manifestRfcProcessor.processPlatform(platRelation.getToCi(), env, nsPath, userId, availMode);
             	DesignCIManifestRfcTouple touple = new DesignCIManifestRfcTouple(platRelation.getToCi().getCiId(),manifestPlatformRfcs);
             	return touple;
-            } finally {
+            } catch (Exception e){
+            	e.printStackTrace();
+            	logger.error(e, e);
+            	throw e;
+			} finally {
 				countDownLatch.countDown();
 				Thread.currentThread().setName(oldThreadName);
             }
         }
- 
     }
 	
 	private class DesignCIManifestRfcTouple {

--- a/transistor/src/test/java/com/oneops/transistor/service/peristenceless/CmsRfcProcessorTest.java
+++ b/transistor/src/test/java/com/oneops/transistor/service/peristenceless/CmsRfcProcessorTest.java
@@ -1,0 +1,42 @@
+package com.oneops.transistor.service.peristenceless;
+
+import com.oneops.cms.dj.domain.CmsRfcCI;
+import com.oneops.cms.dj.service.CmsRfcProcessor;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.testng.Assert.*;
+
+/*******************************************************************************
+ *
+ *   Copyright 2016 Walmart, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ *******************************************************************************/
+public class CmsRfcProcessorTest {
+
+    /**
+     * Making sure InMemory DJMapper doesn't fail getOenRfcCIByCiIdList CmsRfcProcessor call
+     */
+    @Test
+    public void testGetOpenRfcCIByCiIdList(){
+        CmsRfcProcessor processor = new CmsRfcProcessor();
+        processor.setDjMapper(new InMemoryDJMapper());
+        ArrayList<Long> ids = new ArrayList<>();
+        ids.add(1L);
+        assertEquals(0, processor.getOpenRfcCIByCiIdList(ids).size());
+    }
+}

--- a/transistor/src/test/java/com/oneops/transistor/service/peristenceless/InMemoryDJMapperTest.java
+++ b/transistor/src/test/java/com/oneops/transistor/service/peristenceless/InMemoryDJMapperTest.java
@@ -190,6 +190,21 @@ public class InMemoryDJMapperTest {
         assertNull(mapper.getOpenRfcCIByCiId(2L));
     }
 
+    @Test
+    public void testGetOpenRfcCIByCiIdList() {
+        CmsRfcCI rfcCi = new CmsRfcCI();
+        rfcCi.setRfcId(1);
+        rfcCi.setCiId(1);
+        mapper.createRfcCI(rfcCi);
+        CmsRfcCI rfcCi2 = new CmsRfcCI();
+        rfcCi2.setRfcId(2);
+        rfcCi2.setCiId(2);
+        mapper.createRfcCI(rfcCi2);
+        ArrayList<Long> ciIds = new ArrayList<>();
+        ciIds.add(1L);
+        ciIds.add(2L);
+        assertEquals(2, mapper.getOpenRfcCIByCiIdList(ciIds).size());
+    }
 
     @Test
     public void testGetRfcCIBy3() throws Exception {


### PR DESCRIPTION
properly log exception in case of design pull failure since it is executed off thread. 