### PR TITLE
Updated OOCralwer logging format

### DIFF
--- a/crawler/src/main/resources/logback-test.xml
+++ b/crawler/src/main/resources/logback-test.xml
@@ -19,7 +19,7 @@
 		</rollingPolicy>
 		<append>true</append>
 		<encoder>
-			<Pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n
+			<Pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n
 			</Pattern>
 		</encoder>
 	</appender>


### PR DESCRIPTION
Updated OOCralwer logging format, new logging format will look like "2018-03-16 21:19:58.203"