### PR TITLE
Replaced an unnecessary dependency on compute cookbook.

### DIFF
--- a/oneops-admin/lib/shared/cookbooks/monitor/recipes/add.rb
+++ b/oneops-admin/lib/shared/cookbooks/monitor/recipes/add.rb
@@ -351,7 +351,7 @@ ruby_block 'setup nagios' do
       if ostype =~ /windows/
         cmd = node.ssh_cmd.gsub('IP',node.ip) + '"' + 'sudo mkdir -p '+dirs.join(' ')+';' +
          'sudo chown -R oneops:Administrators /var/run/nagios3 /var/log/nagios3 /opt/oneops/perf' + '"'
-	  else
+      else
         cmd = node.ssh_cmd.gsub('IP',node.ip) + '"' + 'sudo mkdir -p '+dirs.join(' ')+';' +
          'sudo chown -R nagios:nagios /var/run/nagios3 /var/log/nagios3 /opt/oneops/perf' + '"'
       end
@@ -360,7 +360,9 @@ ruby_block 'setup nagios' do
       result.error!
 
       # copy default plugins
-      nagios_plugins = node.circuit_dir+'/shared/cookbooks/monitor/files/default/*'
+      nagios_plugins = File.join(
+        File.expand_path('../../', __FILE__), '/files/default/', '*'
+      )
       cmd = node.rsync_cmd.gsub('SOURCE',nagios_plugins).gsub('DEST','~/nagios_libexec/').gsub('IP',node.ip)
       result = shell_out(cmd)
       Chef::Log.info("#{cmd} returned: #{result.stdout}")


### PR DESCRIPTION
By referencing nod.circuit_dir we make this cookbook to depend on
circuit compute cookbook, where that attribute is set.
1) That's a code smell, we dont actually need this attribute to
determine the directory, can use it differently
2) I'm planning to make changes to compute cookbook, one of them
is to stop using circuit_dir attribute