### PR TITLE
Crawler update for new TechDebt requirements

### DIFF
--- a/crawler/src/main/java/com/oneops/crawler/plugins/hadr/PlatformHADRCrawlerPlugin.java
+++ b/crawler/src/main/java/com/oneops/crawler/plugins/hadr/PlatformHADRCrawlerPlugin.java
@@ -1,9 +1,10 @@
 package com.oneops.crawler.plugins.hadr;
 
 import java.io.IOException;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -33,13 +34,16 @@ public class PlatformHADRCrawlerPlugin extends AbstractCrawlerPlugin {
   private String environmentProdProfileFilter;
 
   private String[] produtionCloudsArr; 
-  private String stageCloudFilter;
+  private String prodCloudsListRegex;
   final private String isHALabel="isHA";
   final private String isDRLabel="isDR";
   final private String isAutoRepairEnabledLabel="isAutoRepairEnabled";
   final private String isAutoReplaceEnabledLabel="isAutoReplaceEnabled";
   final private String isProdCloudInNonProdEnvLabel="isProdCloudInNonProdEnv";
-  final  private String prodProfileWithStageCloudsLabel="prodProfileWithStageClouds";
+  final  private String isProdProfileWithNonProdCloudsLabel="isProdProfileWithNonProdClouds";
+  
+  final String dateTimeFormatPattern="yyyy-MM-dd:HH:mm:ss z";
+  final DateTimeFormatter formatter = DateTimeFormatter.ofPattern(dateTimeFormatPattern);
   
   public SearchDal getSearchDal() {
     return searchDal;
@@ -73,10 +77,8 @@ public class PlatformHADRCrawlerPlugin extends AbstractCrawlerPlugin {
     environmentProdProfileFilter = System.getProperty("hadr.env.profile.regex", "prod").toLowerCase();
     log.info("environmentProdProfileFilter: " + environmentProdProfileFilter);
 
-    produtionCloudsArr = System.getProperty("produtionCloudsList").toLowerCase().split("~");
-    
-    stageCloudFilter=System.getProperty("hadr.stageCloudFilter.regex", "stg").toLowerCase();
-    log.info("stageCloudFilter: " + stageCloudFilter);
+    prodCloudsListRegex=System.getProperty("produtionCloudsList").toLowerCase();
+    produtionCloudsArr = prodCloudsListRegex.split("~");
     
     if (isHadrEsEnabled) {
       try {
@@ -123,7 +125,7 @@ public class PlatformHADRCrawlerPlugin extends AbstractCrawlerPlugin {
       platformHADRRecord.setPlatform(platform.getName());
       platformHADRRecord.setAssembly(parseAssemblyNameFromNsPath(platform.getPath()));
       platformHADRRecord.setOoUrl(getOOURL(platform.getPath()));
-      platformHADRRecord.setCreatedTS(new Date());
+      platformHADRRecord.setCreatedTS(formatter.format(ZonedDateTime.now()));
       platformHADRRecord.setCloudsMap(platform.getCloudsMap());
       platformHADRRecord.setSourcePack(platform.getSource() + "-" + platform.getPack());
       platformHADRRecord.setNsPath(platform.getPath());
@@ -242,7 +244,7 @@ public class PlatformHADRCrawlerPlugin extends AbstractCrawlerPlugin {
       }
 
     } catch (Exception e) {
-        log.error("Error while setting cloud categories for cloud {} , error message: {} :",cloudName,e);
+        log.warn("Error while setting cloud categories for cloud {} , error message: {} :",cloudName,e);
         
       }
     }
@@ -265,8 +267,8 @@ public class PlatformHADRCrawlerPlugin extends AbstractCrawlerPlugin {
         && environmentProfileName.toLowerCase().contains(environmentProdProfileFilter)) {
       techDebt.put(isDRLabel, IsDR(platform));
       techDebt.put(isHALabel, IsHA(platform));
-      if (prodProfileWithStageClouds(platform.getCloudsMap())) {
-        techDebt.put(prodProfileWithStageCloudsLabel, true);
+      if (prodProfileWithNonProdClouds(platform.getCloudsMap())) {
+        techDebt.put(isProdProfileWithNonProdCloudsLabel, true);
       }
 
     } else {
@@ -293,10 +295,12 @@ public class PlatformHADRCrawlerPlugin extends AbstractCrawlerPlugin {
 
   }
 
-  public boolean prodProfileWithStageClouds(Map<String, Cloud> cloudsMap) {
-
-    if (cloudsMap.keySet().toString().toLowerCase().contains(stageCloudFilter)) {
-      return true;
+  public boolean prodProfileWithNonProdClouds(Map<String, Cloud> cloudsMap) {
+    
+    for (String platformCloud : cloudsMap.keySet()) {
+      if (!prodCloudsListRegex.contains(platformCloud)) {
+        return true;
+      }
     }
 
     return false;
@@ -351,8 +355,18 @@ public class PlatformHADRCrawlerPlugin extends AbstractCrawlerPlugin {
     return isProdCloudInNonProdEnvLabel;
   }
 
-  public String getProdProfileWithStageCloudsLabel() {
-    return prodProfileWithStageCloudsLabel;
+  public String getIsProdProfileWithNonProdCloudsLabel() {
+    return isProdProfileWithNonProdCloudsLabel;
   }
+
+  public String getEnvironmentProdProfileFilter() {
+    return environmentProdProfileFilter;
+  }
+
+  public String getDateTimeFormatPattern() {
+    return dateTimeFormatPattern;
+  }
+
+
 
 }

--- a/crawler/src/main/java/com/oneops/crawler/plugins/hadr/PlatformHADRCrawlerPlugin.java
+++ b/crawler/src/main/java/com/oneops/crawler/plugins/hadr/PlatformHADRCrawlerPlugin.java
@@ -107,7 +107,11 @@ public class PlatformHADRCrawlerPlugin extends AbstractCrawlerPlugin {
     Collection<Platform> platforms = env.getPlatforms().values();
 
     for (Platform platform : platforms) {
-
+      
+      //ignore processing of platforms which are not enabled.
+      if (platform.getEnable() == null || !platform.getEnable().equalsIgnoreCase("enable")) {
+        continue;
+      }
       PlatformHADRRecord platformHADRRecord = new PlatformHADRRecord();
 
       platformHADRRecord.setEnv(env.getName());

--- a/crawler/src/main/java/com/oneops/crawler/plugins/hadr/PlatformHADRRecord.java
+++ b/crawler/src/main/java/com/oneops/crawler/plugins/hadr/PlatformHADRRecord.java
@@ -18,7 +18,7 @@ public class PlatformHADRRecord implements Serializable {
   private String platform;
   private String ooUrl;
   private String assembly;
-  private Date createdTS;
+  private String createdTS;
   private String env;
   private String pack;
   private String org;
@@ -69,11 +69,11 @@ public class PlatformHADRRecord implements Serializable {
     this.assembly = assembly;
   }
 
-  public Date getCreatedTS() {
+  public String getCreatedTS() {
     return createdTS;
   }
 
-  public void setCreatedTS(Date createdTS) {
+  public void setCreatedTS(String createdTS) {
     this.createdTS = createdTS;
   }
 

--- a/crawler/src/main/resources/hadrIndexMappings.json
+++ b/crawler/src/main/resources/hadrIndexMappings.json
@@ -5,7 +5,7 @@
 				"environmentId": {
 					"type": "integer"
 				},
-				"environmentProfile": {
+				"envProfile": {
 					"type": "string",
 					"index": "not_analyzed"
 				},
@@ -45,16 +45,8 @@
 					"type": "string",
 					"index": "not_analyzed"
 				},
-				"isDR": {
-					"type": "String",
-					"index": "not_analyzed"
-				},
 				"source": {
 					"type": "string",
-					"index": "not_analyzed"
-				},
-				"isHA": {
-					"type": "String",
 					"index": "not_analyzed"
 				},
 				"sourcePack": {

--- a/crawler/src/main/resources/hadrIndexMappings.json
+++ b/crawler/src/main/resources/hadrIndexMappings.json
@@ -10,9 +10,10 @@
 					"index": "not_analyzed"
 				},
 				"createdTS": {
-					"type": "string",
-					"index": "not_analyzed"
-				},
+					"type": "date",
+					"format": "yyyy-MM-dd:HH:mm:ss",
+					"index": "not_analyzed"					
+			    },
 				"nsPath": {
 					"type": "string",
 					"index": "not_analyzed"
@@ -141,7 +142,7 @@
 							"type": "string",
 							"index": "not_analyzed"
 						},
-						"prodProfileWithStageClouds": {
+						"isProdProfileWithNonProdClouds": {
 							"type": "string",
 							"index": "not_analyzed"
 						}

--- a/crawler/src/main/resources/hadrIndexMappings.json
+++ b/crawler/src/main/resources/hadrIndexMappings.json
@@ -11,7 +11,7 @@
 				},
 				"createdTS": {
 					"type": "date",
-					"format": "yyyy-MM-dd:HH:mm:ss",
+					"format": "yyyy-MM-dd:HH:mm:ss z",
 					"index": "not_analyzed"					
 			    },
 				"nsPath": {

--- a/crawler/src/test/java/com/oneops/crawler/plugins/hadr/PlatformHADRCrawlerPluginTest.java
+++ b/crawler/src/test/java/com/oneops/crawler/plugins/hadr/PlatformHADRCrawlerPluginTest.java
@@ -5,7 +5,12 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -36,7 +41,7 @@ public class PlatformHADRCrawlerPluginTest {
     
   }
 
-  @Test(enabled = false)
+  @Test(enabled = true)
   public void test_ReadConfig() {
     plugin = new PlatformHADRCrawlerPlugin();
 
@@ -46,7 +51,7 @@ public class PlatformHADRCrawlerPluginTest {
 
   }
 
-  @Test(enabled = false)
+  @Test(enabled = true)
   private void test_IsDR() {
     plugin = new PlatformHADRCrawlerPlugin();
     Platform platform = new Platform();
@@ -60,7 +65,7 @@ public class PlatformHADRCrawlerPluginTest {
 
   }
 
-  @Test(enabled = false)
+  @Test(enabled = true)
   private void test_IsNonDR() {
     plugin = new PlatformHADRCrawlerPlugin();
     Platform platform = new Platform();
@@ -72,7 +77,7 @@ public class PlatformHADRCrawlerPluginTest {
 
   }
 
-  @Test(enabled = false)
+  @Test(enabled = true)
   private void test_IsHA() {
     plugin = new PlatformHADRCrawlerPlugin();
     Platform platform = new Platform();
@@ -85,7 +90,7 @@ public class PlatformHADRCrawlerPluginTest {
 
   }
 
-  @Test(enabled = false)
+  @Test(enabled = true)
   private void test_IsNonHA() {
     plugin = new PlatformHADRCrawlerPlugin();
     Platform platform = new Platform();
@@ -96,7 +101,7 @@ public class PlatformHADRCrawlerPluginTest {
 
   }
 
-  @Test(enabled = false)
+  @Test(enabled = true)
   private void test_parseAssemblyNameFromNsPath() {
     plugin = new PlatformHADRCrawlerPlugin();
     String nsPath = "/orgname/assemblyname/platformname/bom/env-dev/1";
@@ -104,7 +109,7 @@ public class PlatformHADRCrawlerPluginTest {
 
   }
 
-  @Test(enabled = false)
+  @Test(enabled = true)
   private void test_getOOURL() {
     System.setProperty("hadr.oo.baseurl", "https://oneops.prod.org.com");
     plugin = new PlatformHADRCrawlerPlugin();
@@ -115,7 +120,7 @@ public class PlatformHADRCrawlerPluginTest {
 
   }
 
-  @Test(enabled = false)
+  @Test(enabled = true)
   private void test_getOOURL_DefaultToBlank() {
     System.clearProperty("hadr.oo.baseurl");
     plugin = new PlatformHADRCrawlerPlugin();
@@ -125,7 +130,7 @@ public class PlatformHADRCrawlerPluginTest {
 
   }
 
-  @Test(enabled = false)
+  @Test(enabled = true)
   private void testIsNonProdEnvUsingProdutionClouds() {
     plugin = new PlatformHADRCrawlerPlugin();
     
@@ -156,7 +161,7 @@ public class PlatformHADRCrawlerPluginTest {
     
   }
   
-  @Test(enabled = false)
+  @Test(enabled = true)
   public void testSetCloudCategories(){
     plugin = new PlatformHADRCrawlerPlugin();
     PlatformHADRRecord inputPlatformHADRRecord=new PlatformHADRRecord();
@@ -205,7 +210,7 @@ public class PlatformHADRCrawlerPluginTest {
     
   }
   
-@Test(enabled = false)
+@Test(enabled = true)
   public void testDataTransformation() {
   
   plugin = new PlatformHADRCrawlerPlugin();
@@ -232,7 +237,7 @@ public class PlatformHADRCrawlerPluginTest {
   platform.setSource("oneops");
   expectedESRecord.setSource("oneops");
   expectedESRecord.setSourcePack("oneops-tomcat");
-  platform.setEnable("enabled");
+  platform.setEnable("enable");
   
   platform.setAutoRepairEnabled(true);
   platform.setAutoReplaceEnabled(true);
@@ -436,7 +441,32 @@ public class PlatformHADRCrawlerPluginTest {
     }
   }
 
-
+  @Test(enabled = true)
+  public void testPluginStaticValues() {
+    plugin = new PlatformHADRCrawlerPlugin();
+    
+   String hadrElasticSearchIndexName = "hadr"; 
+   String hadrElasticSearchIndexMappings = "hadrIndexMappings.json"; 
+   String isHALabel="isHA";
+   String isDRLabel="isDR";
+   String isAutoRepairEnabledLabel="isAutoRepairEnabled";
+   String isAutoReplaceEnabledLabel="isAutoReplaceEnabled";
+   String isProdCloudInNonProdEnvLabel="isProdCloudInNonProdEnv";
+   String prodProfileWithNonProdCloudsLabel="isProdProfileWithNonProdClouds";
+   String dateTimeFormatPattern="yyyy-MM-dd:HH:mm:ss z";
+   
+   assertEquals(hadrElasticSearchIndexName, plugin.getHadrElasticSearchIndexName());
+   assertEquals(hadrElasticSearchIndexMappings, plugin.getHadrElasticSearchIndexMappings());
+   assertEquals(isHALabel, plugin.getIsHALabel());
+   assertEquals(isDRLabel, plugin.getIsDRLabel());
+   assertEquals(isAutoRepairEnabledLabel, plugin.getIsAutoRepairEnabledLabel());
+   assertEquals(isAutoReplaceEnabledLabel, plugin.getIsAutoReplaceEnabledLabel());
+   assertEquals(isProdCloudInNonProdEnvLabel, plugin.getIsProdCloudInNonProdEnvLabel());
+   assertEquals(prodProfileWithNonProdCloudsLabel, plugin.getIsProdProfileWithNonProdCloudsLabel());
+   assertEquals(dateTimeFormatPattern, plugin.getDateTimeFormatPattern());
+   
+  }
+  
   private static final class PlatformHADRRecordSubmitted
       extends ArgumentMatcher<PlatformHADRRecord> {
     private final Logger log = LoggerFactory.getLogger(getClass());
@@ -491,26 +521,26 @@ public class PlatformHADRCrawlerPluginTest {
               .get(this.plugin.getIsProdCloudInNonProdEnvLabel()),
           actualESRecord.getTechDebt().get(this.plugin.getIsProdCloudInNonProdEnvLabel()));
 
-      boolean prodProfileWithStageCloudsMatches = matchesBooleanObject(
+      boolean isProdProfileWithNonProdClouds = matchesBooleanObject(
           this.expectedPlatformHADRRecord.getTechDebt()
-              .get(this.plugin.getProdProfileWithStageCloudsLabel()),
-          actualESRecord.getTechDebt().get(this.plugin.getProdProfileWithStageCloudsLabel()));
+              .get(this.plugin.getIsProdProfileWithNonProdCloudsLabel()),
+          actualESRecord.getTechDebt().get(this.plugin.getIsProdProfileWithNonProdCloudsLabel()));
 
 
       log.info(
           "PlatformHADRRecordSubmitted Matchers: <platformNameMatches> {} , <isHAFieldMatches> {}, <isDRFieldMatches> {}, <activeCloudsMatches> {}, "
               + "<offlineCloudsMatches> {}, <primaryCloudsMatches> {}, <secondaryCloudsMatches> {} , <sourceMatches> {}, <sourcePackMatches> {}, "
               + "<isAutoRepairEnabledMatches> {}, <isAutoReplaceEnabledMatches> {}, <orgMatches> {}, <organizationMatches> {} , "
-              + "<isProdCloudInNonProdEnvMatches> {}, <prodProfileWithStageCloudsMatches> {}",
+              + "<isProdCloudInNonProdEnvMatches> {}, <isProdProfileWithNonProdClouds> {}",
           platformNameMatches, isHAFieldMatches, isDRFieldMatches, activeCloudsMatches,
           offlineCloudsMatches, primaryCloudsMatches, secondaryCloudsMatches, sourceMatches,
           sourcePackMatches, isAutoRepairEnabledMatches, isAutoReplaceEnabledMatches, orgMatches,
-          organizationMatches, isProdCloudInNonProdEnvMatches, prodProfileWithStageCloudsMatches);
+          organizationMatches, isProdCloudInNonProdEnvMatches, isProdProfileWithNonProdClouds);
       return (platformNameMatches && isHAFieldMatches && isDRFieldMatches && activeCloudsMatches
           && offlineCloudsMatches && primaryCloudsMatches && secondaryCloudsMatches && sourceMatches
           && sourcePackMatches && isAutoRepairEnabledMatches && isAutoReplaceEnabledMatches
           && orgMatches && organizationMatches && isProdCloudInNonProdEnvMatches
-          && prodProfileWithStageCloudsMatches);
+          && isProdProfileWithNonProdClouds);
     }
 
     public boolean matchesBooleanObject(Object expectedObject, Object actualObject) {

--- a/crawler/src/test/java/com/oneops/crawler/plugins/hadr/PlatformHADRCrawlerPluginTest.java
+++ b/crawler/src/test/java/com/oneops/crawler/plugins/hadr/PlatformHADRCrawlerPluginTest.java
@@ -36,7 +36,7 @@ public class PlatformHADRCrawlerPluginTest {
     
   }
 
-  @Test(enabled = true)
+  @Test(enabled = false)
   public void test_ReadConfig() {
     plugin = new PlatformHADRCrawlerPlugin();
 
@@ -46,7 +46,7 @@ public class PlatformHADRCrawlerPluginTest {
 
   }
 
-  @Test(enabled = true)
+  @Test(enabled = false)
   private void test_IsDR() {
     plugin = new PlatformHADRCrawlerPlugin();
     Platform platform = new Platform();
@@ -60,7 +60,7 @@ public class PlatformHADRCrawlerPluginTest {
 
   }
 
-  @Test(enabled = true)
+  @Test(enabled = false)
   private void test_IsNonDR() {
     plugin = new PlatformHADRCrawlerPlugin();
     Platform platform = new Platform();
@@ -72,7 +72,7 @@ public class PlatformHADRCrawlerPluginTest {
 
   }
 
-  @Test(enabled = true)
+  @Test(enabled = false)
   private void test_IsHA() {
     plugin = new PlatformHADRCrawlerPlugin();
     Platform platform = new Platform();
@@ -85,7 +85,7 @@ public class PlatformHADRCrawlerPluginTest {
 
   }
 
-  @Test(enabled = true)
+  @Test(enabled = false)
   private void test_IsNonHA() {
     plugin = new PlatformHADRCrawlerPlugin();
     Platform platform = new Platform();
@@ -96,7 +96,7 @@ public class PlatformHADRCrawlerPluginTest {
 
   }
 
-  @Test(enabled = true)
+  @Test(enabled = false)
   private void test_parseAssemblyNameFromNsPath() {
     plugin = new PlatformHADRCrawlerPlugin();
     String nsPath = "/orgname/assemblyname/platformname/bom/env-dev/1";
@@ -104,7 +104,7 @@ public class PlatformHADRCrawlerPluginTest {
 
   }
 
-  @Test(enabled = true)
+  @Test(enabled = false)
   private void test_getOOURL() {
     System.setProperty("hadr.oo.baseurl", "https://oneops.prod.org.com");
     plugin = new PlatformHADRCrawlerPlugin();
@@ -115,7 +115,7 @@ public class PlatformHADRCrawlerPluginTest {
 
   }
 
-  @Test(enabled = true)
+  @Test(enabled = false)
   private void test_getOOURL_DefaultToBlank() {
     System.clearProperty("hadr.oo.baseurl");
     plugin = new PlatformHADRCrawlerPlugin();
@@ -125,7 +125,7 @@ public class PlatformHADRCrawlerPluginTest {
 
   }
 
-  @Test(enabled = true)
+  @Test(enabled = false)
   private void testIsNonProdEnvUsingProdutionClouds() {
     plugin = new PlatformHADRCrawlerPlugin();
     
@@ -156,7 +156,7 @@ public class PlatformHADRCrawlerPluginTest {
     
   }
   
-  @Test(enabled = true)
+  @Test(enabled = false)
   public void testSetCloudCategories(){
     plugin = new PlatformHADRCrawlerPlugin();
     PlatformHADRRecord inputPlatformHADRRecord=new PlatformHADRRecord();
@@ -205,7 +205,7 @@ public class PlatformHADRCrawlerPluginTest {
     
   }
   
-@Test(enabled = true)
+@Test(enabled = false)
   public void testDataTransformation() {
   
   plugin = new PlatformHADRCrawlerPlugin();
@@ -346,6 +346,96 @@ public class PlatformHADRCrawlerPluginTest {
   }
   
 }
+
+  @Test(enabled = true)
+  public void testProcessPlatformsInEnvForPlatformEnableField() {
+    try {
+    plugin = new PlatformHADRCrawlerPlugin();
+    SearchDal searchDal = mock(SearchDal.class);
+    plugin.setSearchDal(searchDal);
+
+    String platformCId = "1111";
+    Platform platform = new Platform();
+    platform.setId(Long.valueOf(platformCId));
+    platform.setEnable("disable");
+    
+    Environment env= new Environment(); 
+    env.setProfile("prod");
+    env.addPlatform(platform);
+    
+    
+    PlatformHADRRecord platformHADRRecord = new PlatformHADRRecord();
+
+    
+    Map<String, Organization> organizationsMapCache = new HashMap<String, Organization>();
+    Organization organization = new Organization();
+    organization.setFull_name("testOrgName");
+    platformHADRRecord.setOrg("testOrgName");
+    
+    organization.setOwner("Test-owner");
+    organization.setDescription("Test-description");
+
+    Map<String, String> tags =new HashMap<String, String>();
+    tags.put("CCCID", "Test-cCCID2");
+    tags.put("pillar", "test-pillar2");
+    tags.put("VP", "test-vP2");
+    tags.put("dept", "Test-dept");
+    tags.put("costcenter", "test-costcenter2");
+    tags.put("CTOdirect", "test-cTOdirect2");
+    tags.put("CTO", "Test-cTO2");
+    
+    organization.setTags(tags);
+    organizationsMapCache.put("testOrgName", organization);
+    
+    
+    plugin.processPlatformsInEnv(env, organizationsMapCache);
+    Mockito.verify(searchDal, Mockito.times(0)).put(eq(plugin.getHadrElasticSearchIndexName()), eq("platform"), any(), eq(platformCId));
+   
+    String platformCId2 = "2222";
+    Platform platform2 = new Platform();
+    platform2.setId(Long.valueOf(platformCId2));
+    platform2.setEnable("enable");
+    
+    Environment env2= new Environment(); 
+    env2.setProfile("prod");
+    env2.addPlatform(platform2);
+    
+    plugin.processPlatformsInEnv(env2, organizationsMapCache);
+    Mockito.verify(searchDal, Mockito.times(1)).put(eq(plugin.getHadrElasticSearchIndexName()), eq("platform"), any(), eq(platformCId2));
+    
+   
+    String platformCId3 = "3333";
+    Platform platform3 = new Platform();
+    platform3.setId(Long.valueOf(platformCId3));
+    platform3.setEnable("");
+    
+    Environment env3= new Environment(); 
+    env3.setProfile("prod");
+    env3.addPlatform(platform3);
+    
+    plugin.processPlatformsInEnv(env3, organizationsMapCache);
+    Mockito.verify(searchDal, Mockito.times(0)).put(eq(plugin.getHadrElasticSearchIndexName()), eq("platform"), any(), eq(platformCId3));
+    
+    
+    String platformCId4 = "4444";
+    Platform platform4 = new Platform();
+    platform4.setId(Long.valueOf(platformCId4));
+    platform4.setEnable(null);
+    
+    Environment env4= new Environment(); 
+    env4.setProfile("prod");
+    env4.addPlatform(platform4);
+    
+    plugin.processPlatformsInEnv(env4, organizationsMapCache);
+    Mockito.verify(searchDal, Mockito.times(0)).put(eq(plugin.getHadrElasticSearchIndexName()), eq("platform"), any(), eq(platformCId4));
+    
+
+    } catch (Exception e) {
+      log.error("Error while processing test case: ", e);
+      fail();
+    }
+  }
+
 
   private static final class PlatformHADRRecordSubmitted
       extends ArgumentMatcher<PlatformHADRRecord> {


### PR DESCRIPTION
Added code changes for 

1. PLONEOPS-16212: HA/DR report should report environments with active instances only
2. PLONEOPS-16213: Identify prod profile environments with non-prod clouds