### PR TITLE
Made sure vendor/cache folder on VM has correct owner.

### DIFF
--- a/oneops-admin/lib/shared/exec-order/rubygems.rb
+++ b/oneops-admin/lib/shared/exec-order/rubygems.rb
@@ -188,6 +188,13 @@ def install_using_prebuilt_gemfile (gem_sources, component, provisioner, provisi
           puts "#{cmd} failed with, #{$?}"
           exit 1
         end
+
+        cmd = "chown -R oneops:oneops ./vendor"
+        ec = system cmd
+        if !ec || ec.nil?
+          puts "#{cmd} failed with, #{$?}"
+          exit 1
+        end
       end
     end
 


### PR DESCRIPTION
Any file (gem) we add in vendor/cache during exec-order run will belong to root
because we run exec-order.rb as sudo. But the consecutive rsync command ran by
inductor is ssh-ing to the vm as oneops user and fails due to insufficient
permissions.
Fixed by explicitly changing owner of the vendor folder on the VM to oneops.