### PR TITLE
Added dynamic determination of ruby path for kitchenci.

### DIFF
--- a/inductor/src/main/resources/verification/kitchen-tmpl.yml
+++ b/inductor/src/main/resources/verification/kitchen-tmpl.yml
@@ -1,6 +1,5 @@
 #\<% load "<circuit_root>/monkey_patch.rb" %>
-#\<% chef_path = '$([[ -e "/home/oneops/ruby/2.0.0-p648/bin/chef-solo" ]] && echo "GEM_PATH=/home/oneops/ruby/2.0.0-p648/lib/ruby/gems/2.0.0 GEM_HOME=/home/oneops/ruby/2.0.0-p648/lib/ruby/gems/2.0.0 PATH=/home/oneops/ruby/2.0.0-p648/bin:$PATH /home/oneops/ruby/2.0.0-p648/bin/chef-solo" || echo "<chef_solo_path>")' %>
-#\<% ruby_path = '$([[ -e "/home/oneops/ruby/2.0.0-p648/bin" ]] && echo "/home/oneops/ruby/2.0.0-p648/bin" || echo "<ruby_bindir>")' %>
+#\<% ruby_path = '$(a=$(which ruby);echo ${a///ruby/})' %>
 ---
 <if(local)>
 driver:
@@ -9,14 +8,7 @@ driver:
   reset_command: "exit 0"
   transport: local
 provisioner:
-  name: chef_solo
-  cookbook_files_glob: "**/*"
-  require_chef_omnibus: false
-  chef_solo_path: /usr/local/bin/chef-solo
-  solo_rb:
-    verify_api_cert: true
-    ssl_verify_mode: :verify_peer
-    log_level: :info
+  name: dummy
 verifier:
   name: serverspec
   remote_exec: false
@@ -44,15 +36,7 @@ driver:
   username: <user>
   ssh_key: <ssh_key>
 provisioner:
-  name: chef_solo
-  cookbook_files_glob: "**/*"
-  require_chef_omnibus: false
-  chef_solo_path: \<%= chef_path %>
-  root_path: <provisioner_root_path>
-  solo_rb:
-    verify_api_cert: true
-    ssl_verify_mode: :verify_peer
-    log_level: :info
+  name: dummy
 transport:
   name: rsync
   ssh_key: <ssh_key>


### PR DESCRIPTION
1) replaced chef-solo provisioner with dummy one as we do not run chef recipes
as part of kitchen ci tests and it allows us to simplify the kitchen template.
2) ruby dir is now determined dynamically during kitchenci run, instead of
hard-coding paths.