### PR TITLE
Removed carriage return symbol from the stdout line.

### DIFF
--- a/inductor/src/main/java/com/oneops/inductor/OutputHandler.java
+++ b/inductor/src/main/java/com/oneops/inductor/OutputHandler.java
@@ -81,7 +81,7 @@ public class OutputHandler extends OutputStream {
         line = line + new String(bytes);
 
         if (line.endsWith("\n")) {
-            line = line.substring(0, line.length() - 1);
+            line = line.substring(0, line.length() - 1).replace("\r", "");
             flush();
         }
     }


### PR DESCRIPTION
DOS/Windows machines have different line endings. Need to adjust output handler
so it can remove both line feed and carriage return characters.