### PR TITLE
Soft Quota: Making the resource mapping and usage dynamic

### DIFF
--- a/controller/pom.xml
+++ b/controller/pom.xml
@@ -113,7 +113,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>1.7.1</version>
+      <version>2.7</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>

--- a/transistor/src/main/java/com/oneops/transistor/service/BomAsyncProcessor.java
+++ b/transistor/src/main/java/com/oneops/transistor/service/BomAsyncProcessor.java
@@ -140,8 +140,6 @@ public class BomAsyncProcessor {
 
                 if (className.endsWith(".Compute")) {
                     String size = ciRfc.getAttribute("size").getNewValue();
-                    //int cores = tektonUtils.getTotalCores(size, cloudProviderMapping);
-                    //
                     Map<String, Double> computeResources = tektonUtils.getResources(provider, "compute", "size", size);
 
                     if (computeResources == null) {

--- a/transistor/src/test/java/com/oneops/transistor/service/SoftQuotaTest.java
+++ b/transistor/src/test/java/com/oneops/transistor/service/SoftQuotaTest.java
@@ -55,7 +55,33 @@ public class SoftQuotaTest {
         tektonClientMock = Mockito.mock(TektonClient.class);
         CmsCmProcessor cmsCmProcessor = Mockito.mock(CmsCmProcessor.class);
 
-        String cloudProviderMappings = "[{\"provider\":\"Azure\",\"computeMapping\":[{\"size\":\"M\",\"ip\":1,\"nic\":1,\"cores\":2}]}]";
+        String cloudProviderMappings = "{\n" +
+                "  \"compute\": {\n" +
+                "    \"azure\": {\n" +
+                "      \"size\": {\n" +
+                "        \"M\": {\n" +
+                "          \"Dv2\": 2,\n" +
+                "          \"vm\": 1\n" +
+                "        },\n" +
+                "        \"L\": {\n" +
+                "          \"Dv2\": 6,\n" +
+                "          \"vm\": 1\n" +
+                "        },\n" +
+                "        \"mem-L\": {\n" +
+                "          \"DSv3\": 4,\n" +
+                "          \"vm\": 1\n" +
+                "        }\n" +
+                "      }\n" +
+                "    },\n" +
+                "    \"openstack\": {\n" +
+                "      \"size\": {\n" +
+                "        \"M\": {\n" +
+                "          \"cores\": 4\n" +
+                "        }\n" +
+                "      }\n" +
+                "    }\n" +
+                "  }\n" +
+                "}";
         cmsVarProviderMapping.setValue(cloudProviderMappings);
         cmsVarSoftQuotaEnabled.setValue("true");
         Mockito.when(cmsCmProcessor.getCmSimpleVar(Mockito.eq(TektonUtils.PROVIDER_MAPPINGS_CMS_VAR_NAME))).thenReturn(cmsVarProviderMapping);
@@ -109,14 +135,14 @@ public class SoftQuotaTest {
         String orgName = "oneops";
         String userName = "user1";
 
-        Long deploymentId = bomAsyncProcessor.reserveQuota(bomData, orgName, userName,
-                tektonUtils.getCloudProviderMappings());
+        Long deploymentId = bomAsyncProcessor.reserveQuota(bomData, orgName, userName);
 
         assert(deploymentId > 0);
 
         Map<String, Map<String, Integer>> expectedQuotaRequest = new HashMap<>();
         Map<String, Integer> resources = new HashMap<>();
-        resources.put("cores", 2);
+        resources.put("Dv2", 2);
+        resources.put("vm", 1);
         expectedQuotaRequest.put(SUBSCRIPTION_ID, resources);
 
         Mockito.verify(tektonClientMock, Mockito.times(1))
@@ -162,15 +188,14 @@ public class SoftQuotaTest {
         String orgName = "oneops";
         String userName = "user1";
 
-        Long deploymentId = bomAsyncProcessor.reserveQuota(bomData, orgName, userName,
-                tektonUtils.getCloudProviderMappings());
+        Long deploymentId = bomAsyncProcessor.reserveQuota(bomData, orgName, userName);
 
         assert(deploymentId > 0);
 
         Map<String, Map<String, Integer>> expectedQuotaRequest = new HashMap<>();
         Map<String, Integer> resources = new HashMap<>();
-        resources.put("cores", 2);
-        expectedQuotaRequest.put("Azure", resources);
+        resources.put("Dv2", 2);
+        expectedQuotaRequest.put("azure", resources);
 
         Mockito.verify(tektonClientMock, Mockito.times(0))
                 .reserveQuota(Mockito.anyObject(),
@@ -184,7 +209,7 @@ public class SoftQuotaTest {
         computeUpdateRfc_1.setRfcAction("update");
         cis.add(computeAddRfc_1);
         cis.add(computeUpdateRfc_1);
-        cloudCi.getAttribute("location").setDfValue("/providers/openstack-somecloud");
+        cloudCi.getAttribute("location").setDfValue("/providers/google-somecloud");
 
         CmsRfcRelation deployedToRelationForAdd = createDeployedToRelation(1L, CLOUD_ID, "cdc1");
         CmsRfcRelation deployedToRelationForUpdate = createDeployedToRelation(2L, CLOUD_ID, "cdc1");
@@ -195,15 +220,9 @@ public class SoftQuotaTest {
         String orgName = "oneops";
         String userName = "user1";
 
-        Long deploymentId = bomAsyncProcessor.reserveQuota(bomData, orgName, userName,
-                tektonUtils.getCloudProviderMappings());
+        Long deploymentId = bomAsyncProcessor.reserveQuota(bomData, orgName, userName);
 
         assert(deploymentId > 0);
-
-        Map<String, Map<String, Integer>> expectedQuotaRequest = new HashMap<>();
-        Map<String, Integer> resources = new HashMap<>();
-        resources.put("cores", 2);
-        expectedQuotaRequest.put("Azure", resources);
 
         Mockito.verify(tektonClientMock, Mockito.times(0))
                 .reserveQuota(Mockito.anyObject(),


### PR DESCRIPTION
Made the mapping between oneops class and quota resources dynamic. 
The configuration now looks something like this:
```
{
  "compute": {
    "azure": {
      "size": {
        "M": {
          "Dv2": 2,
          "vm": 1
        },
        "L": {
          "Dv2": 6,
          "vm": 1
        },
        "mem-L": {
          "DSv3": 4,
          "vm": 1
        }
      }
    },
    "openstack": {
      "size": {
        "M": {
          "cores": 4
        }
      }
    }
  }
} ```