### PR TITLE
Fixed a bug with nagios network check.

### DIFF
--- a/oneops-admin/lib/shared/cookbooks/monitor/files/default/check_network_bandwidth.sh
+++ b/oneops-admin/lib/shared/cookbooks/monitor/files/default/check_network_bandwidth.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-stats_dir="/sys/class/net/eth0/statistics"
+interface=$(ip -o -4 route show to default | awk '{print $5}')
+stats_dir="/sys/class/net/$interface/statistics"
 if [ -e $stats_dir ]
  then
   rx_file="$stats_dir/rx_bytes"


### PR DESCRIPTION
Network interface has been hard-coded to eth0 in the script, but in BM clouds
the interface may be different.
Added a dynamic determination of the interface name by using the fact that the
main NIC will usually have a default route.