### PR TITLE
Major version is getting from the pack version platforms_controller.rb

### DIFF
--- a/display/app/controllers/design/platforms_controller.rb
+++ b/display/app/controllers/design/platforms_controller.rb
@@ -73,7 +73,7 @@ class Design::PlatformsController < Base::PlatformsController
   def create
     platform_hash = params[:cms_dj_ci].merge(:nsPath => assembly_ns_path(@assembly), :ciClassName => 'catalog.Platform')
     attrs = platform_hash[:ciAttributes]
-    attrs[:major_version] = 1
+    attrs[:major_version] = attrs[:version]
     attrs[:description] ||= ''
     attr_props = platform_hash.delete(:ciAttrProps)
 


### PR DESCRIPTION
The major version is hardcoded like 1 so whatever data is replaced by 1 so it is now getting from the version.